### PR TITLE
Moved the main() function to a separate file and let SDL replace it with SDL_main properly.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,12 @@
 
 configure_file(resources/projectMSDL.properties.in ${CMAKE_CURRENT_BINARY_DIR}/projectMSDL.properties @ONLY)
 
-add_executable(projectMSDL
+add_executable(projectMSDL WIN32
         AudioCapture.cpp
         AudioCapture.h
         FPSLimiter.cpp
         FPSLimiter.h
+        main.cpp
         ProjectMSDLApplication.cpp
         ProjectMSDLApplication.h
         ProjectMWrapper.cpp
@@ -49,4 +50,5 @@ target_link_libraries(projectMSDL
         libprojectM::${PROJECTM_LINKAGE}
         Poco::Util
         SDL2::SDL2$<$<STREQUAL:"${SDL2_LINKAGE}","static">:"-static">
+        SDL2::SDL2main
         )

--- a/src/ProjectMSDLApplication.cpp
+++ b/src/ProjectMSDLApplication.cpp
@@ -1,3 +1,7 @@
+// Keep it as the first line, as SDL2 will otherwise redefine
+// ProjectMSDLApplication::main to ProjectMSDLApplication::SDL_main
+#define SDL_MAIN_HANDLED
+
 #include "ProjectMSDLApplication.h"
 
 #include "AudioCapture.h"
@@ -164,5 +168,3 @@ void ProjectMSDLApplication::ListAudioDevices(POCO_UNUSED const std::string& nam
 {
     _commandLineOverrides->setBool("audio.listDevices", true);
 }
-
-POCO_APP_MAIN(ProjectMSDLApplication)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,18 @@
+#include "ProjectMSDLApplication.h"
+
+#include <SDL2/SDL.h>
+
+int main(int argc, char* argv[])
+{
+    Poco::AutoPtr<ProjectMSDLApplication> pApp = new ProjectMSDLApplication;
+    try
+    {
+        pApp->init(argc, argv);
+    }
+    catch (Poco::Exception& exc)
+    {
+        pApp->logger().log(exc);
+        return Poco::Util::Application::EXIT_CONFIG;
+    }
+    return pApp->run();
+}


### PR DESCRIPTION
Using SDL's main function is required on some platforms like Windows and macOS to perform some early initialization and cleanups on shutdown. Since SDL defines a `main` macro, this will replace the `ProjectMSDLApplication::main` function with `ProjectMSDLApplication::SDL_main`, which will break things.

To circumvent this, I needed to do a few things:

1. Move the main function that creates. the Poco application to its own implementation file.
2. No longer use Poco's `POCO_APP_MAIN` macro, as this defines the main function as `wmain` on Windows - SDL2 expects it as `main`.
3. Link the SDLmain static library.
4. Add `WIN32` in CMake's target definition to compile it as a GUI application, which will use the `WinMain` entry point and not show a console window.