### PR TITLE
Fixed broken build

### DIFF
--- a/src/AudioCapture.cpp
+++ b/src/AudioCapture.cpp
@@ -4,6 +4,8 @@
 
 #include <Poco/Util/Application.h>
 
+#include <iostream>
+
 const char* AudioCapture::name() const
 {
     return "Audio Capturing";

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,15 +38,19 @@ else()
             )
 endif()
 
+find_package(libprojectM REQUIRED)
 target_compile_definitions(projectMSDL
         PRIVATE
         PROJECTMSDL_VERSION="${PROJECT_VERSION}"
         LIBPROJECTM_BUILD_VERSION="${libprojectM_VERSION}"
         )
 
+find_package(OpenMP REQUIRED)
 target_link_libraries(projectMSDL
         PRIVATE
-        libprojectM::${PROJECTM_LINKAGE}
+        libprojectM.a #::${PROJECTM_LINKAGE}
+        OpenGL::GL
+        OpenMP::OpenMP_CXX
         Poco::Util
         SDL2::SDL2$<$<STREQUAL:"${SDL2_LINKAGE}","static">:"-static">
-        )
+       )

--- a/src/ProjectMSDLApplication.cpp
+++ b/src/ProjectMSDLApplication.cpp
@@ -10,6 +10,8 @@
 
 #include <Poco/Util/HelpFormatter.h>
 
+#include <iostream>
+
 ProjectMSDLApplication::ProjectMSDLApplication()
     : Poco::Util::Application()
 {


### PR DESCRIPTION
The build is broken on master because of broken references comprising:

- Missing #includes,
- Missing linkage to various libraries, and
- Incorrect specification of linkage to projectM


This PR fixes the build. Suggest automated tests in the future.