### PR TITLE
Make code compile with older versions of Poco

### DIFF
--- a/src/AudioCapture.cpp
+++ b/src/AudioCapture.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include "AudioCapture.h"
 
 #include "ProjectMWrapper.h"

--- a/src/AudioCapture.h
+++ b/src/AudioCapture.h
@@ -56,7 +56,7 @@ protected:
      */
     int GetInitialAudioDeviceIndex(const std::map<int, std::string>& deviceList);
 
-    Poco::Util::AbstractConfiguration::Ptr _config; //!< View of the "audio" configuration subkey.
+    Poco::AutoPtr<Poco::Util::AbstractConfiguration> _config; //!< View of the "audio" configuration subkey.
 
     std::unique_ptr<AudioCaptureImpl> _impl; //!< The OS-specific capture implementation.
 

--- a/src/ProjectMSDLApplication.cpp
+++ b/src/ProjectMSDLApplication.cpp
@@ -10,6 +10,8 @@
 
 #include <Poco/Util/HelpFormatter.h>
 
+#include <iostream>
+
 ProjectMSDLApplication::ProjectMSDLApplication()
     : Poco::Util::Application()
 {

--- a/src/ProjectMSDLApplication.h
+++ b/src/ProjectMSDLApplication.h
@@ -28,8 +28,8 @@ protected:
 
     void ListAudioDevices(const std::string& name, const std::string& value);
 
-    Poco::Util::MapConfiguration::Ptr _commandLineOverrides{
-        Poco::makeAuto<Poco::Util::MapConfiguration>() }; //!< Map configuration with overrides set by command line arguments.
+    Poco::AutoPtr<Poco::Util::MapConfiguration> _commandLineOverrides{
+        new Poco::Util::MapConfiguration() }; //!< Map configuration with overrides set by command line arguments.
 };
 
 

--- a/src/ProjectMWrapper.h
+++ b/src/ProjectMWrapper.h
@@ -7,6 +7,8 @@
 #include <Poco/Util/Subsystem.h>
 #include <Poco/Util/AbstractConfiguration.h>
 
+#include <memory>
+
 class ProjectMWrapper : public Poco::Util::Subsystem
 {
 public:
@@ -31,7 +33,7 @@ public:
 
 
 protected:
-    Poco::Util::AbstractConfiguration::Ptr _config; //!< View of the "projectM" configuration subkey.
+    Poco::AutoPtr<Poco::Util::AbstractConfiguration> _config; //!< View of the "projectM" configuration subkey.
 
     projectm* _projectM{ nullptr }; //!< Pointer to the projectM instance used by the application.
 

--- a/src/SDLRenderingWindow.cpp
+++ b/src/SDLRenderingWindow.cpp
@@ -143,8 +143,9 @@ void SDLRenderingWindow::NextDisplay()
         SDL_Rect bounds;
         SDL_GetDisplayBounds(display, &bounds);
 
-        poco_debug_f(_logger, "Bounds for display %?d: X=%?d Y=%?d W=%?d H=%?d",
-                      display, bounds.x, bounds.y, bounds.w, bounds.h);
+        std::stringstream debugOutput;
+        poco_debug_f1(_logger, "Bounds for display %?d:", display);
+        poco_debug_f4(_logger, "    X=%?d Y=%?d W=%?d H=%?d", bounds.x, bounds.y, bounds.w, bounds.h);
 
         // Need to add 1 to left and top, as some window managers will screw up here.
         if (left + 1 >= bounds.x && left + 1 < bounds.x + bounds.w
@@ -182,7 +183,7 @@ void SDLRenderingWindow::NextDisplay()
 
         SDL_SetWindowPosition(_renderingWindow, newLeft, newTop);
 
-        poco_debug_f(_logger, "Old position: X=%?d Y=%?d, new position: X=%?d Y=%?d.",
+        poco_debug_f4(_logger, "Old position: X=%?d Y=%?d, new position: X=%?d Y=%?d.",
                      left, top, newLeft, newTop);
     }
 

--- a/src/SDLRenderingWindow.h
+++ b/src/SDLRenderingWindow.h
@@ -85,7 +85,7 @@ protected:
      */
     void DumpOpenGLInfo();
 
-    Poco::Util::AbstractConfiguration::Ptr _config; //!< View of the "window" configuration subkey.
+    Poco::AutoPtr<Poco::Util::AbstractConfiguration> _config; //!< View of the "window" configuration subkey.
 
     SDL_Window* _renderingWindow{ nullptr }; //!< Pointer to the SDL window used for rendering.
     SDL_GLContext _glContext{ nullptr }; //!< Pointer to the OpenGL context associated with the window.


### PR DESCRIPTION
Made some changes so that it could compile on my computer with Poco 1.9.2.

I opted for the smallest changes that would make it compile, but it could also be worthwhile to try moving from Poco's smart pointers to the ones available in the standard library.