### PR TITLE
Few fixes to make the app compile properly on macOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ find_package(libprojectM REQUIRED)
 find_package(SDL2 REQUIRED)
 find_package(Poco REQUIRED COMPONENTS Util)
 
+include(SDL2Target)
 include(dependencies_check.cmake)
 
 add_subdirectory(src)

--- a/src/AudioCapture.h
+++ b/src/AudioCapture.h
@@ -8,7 +8,6 @@
 #include <Poco/Util/AbstractConfiguration.h>
 
 #include <memory>
-#include <bits/stl_map.h>
 
 /**
  * @brief Audio capturing proxy class/subsystem.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,4 +51,5 @@ target_link_libraries(projectMSDL
         Poco::Util
         SDL2::SDL2$<$<STREQUAL:"${SDL2_LINKAGE}","static">:"-static">
         SDL2::SDL2main
+        OpenGL::GL
         )

--- a/src/ProjectMWrapper.cpp
+++ b/src/ProjectMWrapper.cpp
@@ -4,7 +4,7 @@
 
 #include <Poco/Util/Application.h>
 
-#include <GL/gl.h>
+#include <SDL2/SDL_opengl.h>
 
 const char* ProjectMWrapper::name() const
 {

--- a/src/SDLRenderingWindow.cpp
+++ b/src/SDLRenderingWindow.cpp
@@ -1,10 +1,8 @@
 #include "SDLRenderingWindow.h"
 
-#include <libprojectM/projectM.h>
-
 #include <Poco/Util/Application.h>
 
-#include <GL/gl.h>
+#include <SDL2/SDL_opengl.h>
 
 const char* SDLRenderingWindow::name() const
 {


### PR DESCRIPTION
- Removed a non-standard include that sneaked in.
- Replaced OS-specific OpenGL includes with SDL's OpenGL header.
- Link OpenGL library and apply SDL2 path fixes.