### PR TITLE
Added a few tweaks to be able to build the app as an all-static executable, using /MT[d] on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 if(CMAKE_VERSION VERSION_LESS 3.19 AND CMAKE_GENERATOR STREQUAL "Xcode")
     message(AUTHOR_WARNING "Using a CMake version before 3.19 with a recent Xcode SDK and the Xcode generator "

--- a/cmake/SDL2Target.cmake
+++ b/cmake/SDL2Target.cmake
@@ -55,9 +55,17 @@ endif()
 
 # Temporary fix to deal with wrong include dir set by SDL2's CMake configuration.
 get_target_property(_SDL2_INCLUDE_DIR SDL2::SDL2 INTERFACE_INCLUDE_DIRECTORIES)
-if(_SDL2_INCLUDE_DIR MATCHES "(.+)/SDL2\$")
+if(_SDL2_INCLUDE_DIR MATCHES "(.+)/SDL2\$" AND _SDL2_TARGET_TYPE STREQUAL STATIC_LIBRARY)
+    # Check if SDL2::SDL2 is aliased to SDL2::SDL2-static (will be the case for static-only builds)
+    get_target_property(_SDL2_ALIASED_TARGET SDL2::SDL2 ALIASED_TARGET)
+    if(_SDL2_ALIASED_TARGET)
+        set(_sdl2_target ${_SDL2_ALIASED_TARGET})
+    else()
+        set(_sdl2_target SDL2::SDL2)
+    endif()
+
     message(STATUS "SDL2 include dir contains \"SDL2\" subdir (SDL bug #4004) - fixing to \"${CMAKE_MATCH_1}\".")
-    set_target_properties(SDL2::SDL2 PROPERTIES
+    set_target_properties(${_sdl2_target} PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_MATCH_1}"
             )
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,20 @@ target_link_libraries(projectMSDL
         PRIVATE
         libprojectM::${PROJECTM_LINKAGE}
         Poco::Util
-        SDL2::SDL2$<$<STREQUAL:"${SDL2_LINKAGE}","static">:"-static">
+        SDL2::SDL2$<$<STREQUAL:${SDL2_LINKAGE},static>:-static>
         SDL2::SDL2main
-        OpenGL::GL
         )
+
+if(MSVC)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.16")
+        set_target_properties(projectMSDL
+                PROPERTIES
+                VS_DPI_AWARE "PerMonitor"
+                )
+    else()
+        message(AUTHOR_WARNING
+                "You're using a CMake version less than 3.16 with Visual Studio.\n"
+                "The resulting projectMSDL executable will not be DPI-aware and possibly render at a "
+                "lower-than-expected resolution on high-DPI displays.")
+    endif()
+endif()


### PR DESCRIPTION
Had to increase the minimum CMake requirement to 3.15, otherwise the CMAKE_MSVC_RUNTIME_LIBRARY won't work and devs can't easily use the static runtime.