### PR TITLE
Add texture path option

### DIFF
--- a/src/ProjectMSDLApplication.cpp
+++ b/src/ProjectMSDLApplication.cpp
@@ -77,6 +77,10 @@ void ProjectMSDLApplication::defineOptions(Poco::Util::OptionSet& options)
                              false, "<path>", true)
                           .binding("projectM.presetPath", _commandLineOverrides));
 
+    options.addOption(Option("texturePath", "", "Additional path with textures/images.",
+                             false, "<path>", true)
+                          .binding("projectM.texturePath", _commandLineOverrides));
+
     options.addOption(Option("enableSplash", "s", "If true, initially displays the built-in projectM logo preset.",
                              false, "<0/1>", true)
                           .binding("projectM.enableSplash", _commandLineOverrides));

--- a/src/ProjectMWrapper.cpp
+++ b/src/ProjectMWrapper.cpp
@@ -25,6 +25,7 @@ void ProjectMWrapper::initialize(Poco::Util::Application& app)
         sdlWindow.GetDrawableSize(canvasWidth, canvasHeight);
 
         auto presetPath = _config->getString("presetPath", app.config().getString("application.dir", ""));
+        auto texturePath = _config->getString("texturePath", app.config().getString("", ""));
 
         projectm_settings settings{};
 
@@ -44,12 +45,17 @@ void ProjectMWrapper::initialize(Poco::Util::Application& app)
         settings.hard_cut_sensitivity = static_cast<float>(_config->getDouble("hardCutSensitivity", 1.0));
         settings.beat_sensitivity = static_cast<float>(_config->getDouble("beatSensitivity", 1.0));
         settings.shuffle_enabled = _config->getBool("shuffleEnabled", true);
-        settings.preset_url = &presetPath[0];
+        if (!presetPath.empty())
+        {
+            settings.preset_path = &presetPath[0];
+        }
+        if (!texturePath.empty())
+        {
+            settings.texture_path = &texturePath[0];
+        }
 
         // Unsupported settings
         settings.soft_cut_ratings_enabled = false;
-        settings.menu_font_url = nullptr;
-        settings.title_font_url = nullptr;
 
         _projectM = projectm_create_settings(&settings, PROJECTM_FLAG_NONE);
 

--- a/src/resources/projectMSDL.properties.in
+++ b/src/resources/projectMSDL.properties.in
@@ -28,22 +28,55 @@ window.height = 768
 # This will limit max FPS to the vertical sync frequency but prevent tearing.
 window.waitForVerticalSync = true
 
+
 ### projectM settings
+
+# Path where projectMSDL will search for presets and textures. The directory will be searched recursively.
+projectM.presetPath = @DEFAULT_PRESET_PATH@
+
+# Optional path where projectMSDL will search for additional textures. The directory will be searched recursively.
+# Note that textures found under "presetPath" will override textures in the texturePath dir.
+#projectM.texturePath =
 
 # If true, displays the built-in projectM logo preset on startup.
 projectM.enableSplash = false
 
+# Preset display duration in seconds. If the time has passed, a soft cut is done to the next preset.
+projectM.displayDuration = 30
+
+# If enabled, presets are selected randomly from the current playlist. Otherwise, they are played in order.
+projectM.shuffleEnabled = true
+
 # Target FPS, usually 60.
 projectM.fps = 60
-# Render mesh size. This is the grid in which "per-pixel" code is executed, once per cell.
+
+# Per-pixel mesh size. This is the grid in which "per-pixel" code is executed, once per cell.
+# Do net set this value too high, as it severely impacts performance. On low-end hardware, set this to a smal
+# value, e.g. 64x32. This does *NOT* affect the actual render/shader resolution!
 projectM.meshX = 200
 projectM.meshY = 125
 
 # Transition time in seconds for soft cuts
 projectM.transitionDuration = 3
 
-# Path where projectMSDL will search for presets and textures. The directory will be searched recursively.
-projectM.presetPath = @DEFAULT_PRESET_PATH@
+# Hard cuts are immediate presets transitions on an intensive beat.
+# If enabled, after "hardCutDuration" seconds have passed and an intensive beat is detected,
+# a hard cut is performed. "hardCutDuration" should be set lower than "displayDuration" to have an effect.
+projectM.hardCutsEnabled = false
+projectM.hardCutDuration = 20
+
+# Controls aspect ration correction in presets. Not all presets use aspect ratio, so this setting  only has an effect
+# on presets using the aspect ration actively.
+projectM.aspectCorrectionEnabled = true
+
+
+### Logging settings
+
+# For detailed information on how to configure logging, please refer to the POCO documentation:
+# https://docs.pocoproject.org/current/Poco.Util.LoggingConfigurator.html
+
+# Set log level to debug for all components
+#logging.loggers.root.level = debug
 
 
 


### PR DESCRIPTION
Add option to specify an additional texture path. Helpful if the user's custom preset dir doesn't contain all the Milkdrop textures or the user wants a specific image dir to be used.

Depends on https://github.com/projectM-visualizer/projectm/pull/624