### PR TITLE
Check viewport size every frame and resize projectM if changed.

### DIFF
--- a/src/RenderLoop.cpp
+++ b/src/RenderLoop.cpp
@@ -33,6 +33,7 @@ void RenderLoop::Run()
     {
         limiter.StartFrame();
         PollEvents();
+        CheckViewportSize();
         _audioCapture.FillBuffer();
         _projectMWrapper.RenderFrame();
         _sdlRenderingWindow.Swap();
@@ -50,32 +51,6 @@ void RenderLoop::PollEvents()
     {
         switch (event.type)
         {
-            case SDL_WINDOWEVENT:
-                switch (event.window.event)
-                {
-                    case SDL_WINDOWEVENT_RESIZED:
-                    case SDL_WINDOWEVENT_SIZE_CHANGED:
-                    {
-                        int renderWidth;
-                        int renderHeight;
-                        _sdlRenderingWindow.GetDrawableSize(renderWidth, renderHeight);
-
-                        if (renderWidth != _renderWidth || renderHeight != _renderHeight)
-                        {
-                            projectm_set_window_size(_projectMHandle, renderWidth, renderHeight);
-                            _renderWidth = renderWidth;
-                            _renderHeight = renderHeight;
-
-                            poco_debug_f2(_logger, "Resized rendering canvas to %?dx%?d.", renderWidth, renderHeight);
-                        }
-                    }
-                        break;
-
-                    default:
-                        break;
-                }
-                break;
-
             case SDL_MOUSEWHEEL:
                 ScrollEvent(event.wheel);
                 break;
@@ -118,6 +93,22 @@ void RenderLoop::PollEvents()
                 _wantsToQuit = true;
                 break;
         }
+    }
+}
+
+void RenderLoop::CheckViewportSize()
+{
+    int renderWidth;
+    int renderHeight;
+    _sdlRenderingWindow.GetDrawableSize(renderWidth, renderHeight);
+
+    if (renderWidth != _renderWidth || renderHeight != _renderHeight)
+    {
+        projectm_set_window_size(_projectMHandle, renderWidth, renderHeight);
+        _renderWidth = renderWidth;
+        _renderHeight = renderHeight;
+
+        poco_debug_f2(_logger, "Resized rendering canvas to %?dx%?d.", renderWidth, renderHeight);
     }
 }
 

--- a/src/RenderLoop.h
+++ b/src/RenderLoop.h
@@ -29,6 +29,11 @@ protected:
     void PollEvents();
 
     /**
+     * @brief Checks if the GL viewport size has changed and if so, reconfigured projectM accordingly.
+     */
+    void CheckViewportSize();
+
+    /**
      * @brief Handles SDL key press events.
      * @param event The key event.
      */


### PR DESCRIPTION
SDL's resize events are sometimes unreliable, e.g, if using the green "fullscreen" button on macOS or toggling to the borderless, non-exclusive fullscreen mode on Linux. Getting the GL drawable size is fast and also reliable, so we can simply check it on each frame. Will also take care of DPI changes.