### PR TITLE
A couple of fixes and improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 set(PROJECTM_LINKAGE "shared" CACHE STRING "Set to either shared or static to specify how libprojectM should be linked. Defaults to shared.")
 set(SDL2_LINKAGE "shared" CACHE STRING "Set to either shared or static to specify how libSDL2 should be linked. Defaults to shared.")
 
+set(DEFAULT_PRESETS_PATH "\${application.dir}/presets" CACHE STRING "Default presets path in the configuration file.")
+set(DEFAULT_TEXTURES_PATH "\${application.dir}/textures" CACHE STRING "Default textures path in the configuration file.")
+
 if(NOT PROJECTM_LINKAGE STREQUAL "shared" AND NOT PROJECTM_LINKAGE STREQUAL "static")
     message(FATAL_ERROR "Invalid libprojectM linkage provided in PROJECTM_LINKAGE: \"${PROJECTM_LINKAGE}\".\n"
                         "Please specify either \"shared\" or \"static\"."

--- a/install.cmake
+++ b/install.cmake
@@ -1,0 +1,8 @@
+# ToDo: Make directory structure configurable
+install(TARGETS projectMSDL
+        RUNTIME DESTINATION .
+        )
+
+install(FILES ${PROJECTM_CONFIGURATION_FILE}
+        DESTINATION .
+        )

--- a/src/AudioCaptureImpl_SDL.cpp
+++ b/src/AudioCaptureImpl_SDL.cpp
@@ -25,7 +25,15 @@ std::map<int, std::string> AudioCaptureImpl::AudioDeviceList()
 
     for (int i = 0; i < recordingDeviceCount; i++)
     {
-        deviceList.insert(std::make_pair(i, SDL_GetAudioDeviceName(i, true)));
+        auto deviceName = SDL_GetAudioDeviceName(i, true);
+        if (deviceName)
+        {
+            deviceList.insert(std::make_pair(i, deviceName));
+        }
+        else
+        {
+            poco_error_f2(_logger, "Could not get device name for device ID %d: %s", i, std::string(SDL_GetError()));
+        }
     }
 
     return deviceList;
@@ -68,7 +76,14 @@ void AudioCaptureImpl::NextAudioDevice()
 
 std::string AudioCaptureImpl::AudioDeviceName() const
 {
-    return SDL_GetAudioDeviceName(_currentAudioDeviceIndex, true);
+    if (_currentAudioDeviceIndex >= 0)
+    {
+        return SDL_GetAudioDeviceName(_currentAudioDeviceIndex, true);
+    }
+    else
+    {
+        return "Default capturing device";
+    }
 }
 
 bool AudioCaptureImpl::OpenAudioDevice()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 
-configure_file(resources/projectMSDL.properties.in ${CMAKE_CURRENT_BINARY_DIR}/projectMSDL.properties @ONLY)
+set(PROJECTM_CONFIGURATION_FILE "${CMAKE_CURRENT_BINARY_DIR}/projectMSDL.properties" PARENT_SCOPE)
+configure_file(resources/projectMSDL.properties.in ${PROJECTM_CONFIGURATION_FILE} @ONLY)
 
 add_executable(projectMSDL WIN32
         AudioCapture.cpp

--- a/src/resources/projectMSDL.properties.in
+++ b/src/resources/projectMSDL.properties.in
@@ -32,11 +32,11 @@ window.waitForVerticalSync = true
 ### projectM settings
 
 # Path where projectMSDL will search for presets and textures. The directory will be searched recursively.
-projectM.presetPath = @DEFAULT_PRESET_PATH@
+projectM.presetPath = @DEFAULT_PRESETS_PATH@
 
 # Optional path where projectMSDL will search for additional textures. The directory will be searched recursively.
 # Note that textures found under "presetPath" will override textures in the texturePath dir.
-#projectM.texturePath =
+projectM.texturePath = @DEFAULT_TEXTURES_PATH@
 
 # If true, displays the built-in projectM logo preset on startup.
 projectM.enableSplash = false


### PR DESCRIPTION
Three small improvements:
- Fix potentially using a nullptr in `std::string` construction
- Add default paths for presets and textures to the properties file and make them configurable via CMake variables
- Add (very basic) install commands for the executable and properties file