### PR TITLE
Preset filter and block list

### DIFF
--- a/src/ProjectMSDLApplication.cpp
+++ b/src/ProjectMSDLApplication.cpp
@@ -140,10 +140,25 @@ void ProjectMSDLApplication::defineOptions(Poco::Util::OptionSet& options)
                              false, "<number>", true)
                           .binding("projectM.displayDuration", _commandLineOverrides));
 
+    options.addOption(Option("transitionDuration", "", "Transition duration. Any number >= 0, default 3.",
+                             false, "<number>", true)
+                          .binding("projectM.transitionDuration", _commandLineOverrides));
+
+    options.addOption(Option("hardCutsEnabled", "", "Hard cuts enabled.",
+                             false, "<0/1>", true)
+                          .binding("projectM.hardCutsEnabled", _commandLineOverrides));
+
+    options.addOption(Option("hardCutDuration", "", "Hard cut duration. Any number > 1, default 20.",
+                             false, "<number>", true)
+                          .binding("projectM.hardCutDuration", _commandLineOverrides));
+
+    options.addOption(Option("hardCutSensitivity", "", "Hard cut sensitivity. Between 0.0 and 5.0. Default 1.0.",
+                             false, "<number>", true)
+                          .binding("projectM.hardCutSensitivity", _commandLineOverrides));
+
     options.addOption(Option("beatSensitivity", "", "Beat sensitivity. Between 0.0 and 5.0. Default 1.0.",
                              false, "<number>", true)
                           .binding("projectM.beatSensitivity", _commandLineOverrides));
-
 }
 
 int ProjectMSDLApplication::main(POCO_UNUSED const std::vector<std::string>& args)

--- a/src/ProjectMSDLApplication.cpp
+++ b/src/ProjectMSDLApplication.cpp
@@ -77,6 +77,10 @@ void ProjectMSDLApplication::defineOptions(Poco::Util::OptionSet& options)
                              false, "<path>", true)
                           .binding("projectM.presetPath", _commandLineOverrides));
 
+    options.addOption(Option("presetFilter", "", "Load presets with the filter in their path, e.g. 'Dancer/Aurora'",
+                             false, "<text>", true)
+                          .binding("presetFilter", _commandLineOverrides));
+
     options.addOption(Option("texturePath", "", "Additional path with textures/images.",
                              false, "<path>", true)
                           .binding("projectM.texturePath", _commandLineOverrides));

--- a/src/ProjectMSDLApplication.cpp
+++ b/src/ProjectMSDLApplication.cpp
@@ -36,14 +36,20 @@ void ProjectMSDLApplication::initialize(Poco::Util::Application& self)
 
     loadConfiguration(PRIO_DEFAULT);
 
-    // Try to load user's custom configuration file on top.
-    Poco::Path userConfigurationFile =
-        Poco::Path::configHome() + "projectM" + Poco::Path::separator() + "projectMSDL.properties";
-    if (Poco::File(userConfigurationFile).exists())
-    {
-        loadConfiguration(userConfigurationFile.toString(), PRIO_DEFAULT - 10);
-    }
+    // create config dir
+    Poco::Path configDir(config().getString("application.configDir"));
+    Poco::File(configDir).createDirectory();
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Config dir '%s'\n", configDir.toString().c_str());
 
+    // set default config
+    config().setString("projectM.presetExcludeFile", Poco::Path(configDir, "exclude.txt").toString());
+
+    // Try to load user's custom configuration file on top.
+    Poco::Path configFile = Poco::Path(configDir, "projectMSDL.properties");
+    if (Poco::File(configFile).exists())
+    {
+        loadConfiguration(configFile.toString(), PRIO_DEFAULT - 10);
+    }
 
     Application::initialize(self);
 }
@@ -77,9 +83,13 @@ void ProjectMSDLApplication::defineOptions(Poco::Util::OptionSet& options)
                              false, "<path>", true)
                           .binding("projectM.presetPath", _commandLineOverrides));
 
-    options.addOption(Option("presetFilter", "", "Load presets with the filter in their path, e.g. 'Dancer/Aurora'",
+    options.addOption(Option("presetExcludeFile", "", "File with additional list of presets to exclude",
+                             false, "<path>", true)
+                          .binding("projectM.presetExcludeFile", _commandLineOverrides));
+
+    options.addOption(Option("presetFilter", "", "Include only presets with the filter in their path, e.g. 'Dancer/Aurora'",
                              false, "<text>", true)
-                          .binding("presetFilter", _commandLineOverrides));
+                          .binding("projectM.presetFilter", _commandLineOverrides));
 
     options.addOption(Option("texturePath", "", "Additional path with textures/images.",
                              false, "<path>", true)

--- a/src/ProjectMWrapper.cpp
+++ b/src/ProjectMWrapper.cpp
@@ -133,6 +133,4 @@ void ProjectMWrapper::SetHelpText()
                            modKey + "+M: Change monitor\n" +
                            modKey + "+F: Toggle fullscreen\n" +
                            modKey + "+Q: Quit projectM";
-
-    projectm_set_help_text(_projectM, helpText.c_str());
 }

--- a/src/RenderLoop.cpp
+++ b/src/RenderLoop.cpp
@@ -288,14 +288,17 @@ void RenderLoop::KeyEvent(const SDL_KeyboardEvent& event, bool down)
             break;
 
         case SDLK_MINUS:
+            auto excludeFile = Poco::Util::Application::instance().config().getString("projectM.presetExcludeFile");
+
             unsigned int index = 0;
             if (projectm_get_selected_preset_index(_projectMHandle, &index)) {
                 const char* presetName = projectm_get_preset_name(_projectMHandle, index);
-                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "add to blocklist.txt %s\n", presetName);
 
                 std::ofstream outfile;
-                outfile.open("blocklist.txt", std::ios_base::app);
+                outfile.open(excludeFile, std::ios_base::app);
                 outfile << presetName << "\n";
+
+                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Add exclusion %s %s\n", excludeFile.c_str(), presetName);
 
                 projectm_remove_preset(_projectMHandle, index);
                 projectm_select_preset(_projectMHandle, index, true);

--- a/src/RenderLoop.cpp
+++ b/src/RenderLoop.cpp
@@ -423,9 +423,5 @@ void RenderLoop::PresetSwitchedEvent(bool isHardCut, unsigned int index, void* c
     auto that = reinterpret_cast<RenderLoop*>(context);
     auto presetName = projectm_get_preset_name(that->_projectMHandle, index);
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Displaying preset: %s\n", presetName);
-
-    std::string newTitle = "projectM ➫ " + std::string(presetName);
     projectm_free_string(presetName);
-
-    that->_sdlRenderingWindow.SetTitle(newTitle);
 }

--- a/src/RenderLoop.cpp
+++ b/src/RenderLoop.cpp
@@ -146,6 +146,7 @@ void RenderLoop::KeyEvent(const SDL_KeyboardEvent& event, bool down)
         {
             bool aspectCorrectionEnabled = !projectm_get_aspect_correction(_projectMHandle);
             projectm_set_aspect_correction(_projectMHandle, aspectCorrectionEnabled);
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, aspectCorrectionEnabled ? "Aspect Correction Enabled" : "Aspect Correction Disabled");
         }
             break;
 
@@ -153,6 +154,7 @@ void RenderLoop::KeyEvent(const SDL_KeyboardEvent& event, bool down)
         case SDLK_d:
             // Write next rendered frame to file
             projectm_key_handler(_projectMHandle, PROJECTM_KEYDOWN, PROJECTM_K_d, PROJECTM_KMOD_NONE);
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Main Texture Captured");
             break;
 #endif
 
@@ -172,6 +174,7 @@ void RenderLoop::KeyEvent(const SDL_KeyboardEvent& event, bool down)
             if (modifierPressed)
             {
                 _audioCapture.NextAudioDevice();
+                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "%s", _audioCapture.AudioDeviceName().c_str());
             }
             break;
 
@@ -209,6 +212,7 @@ void RenderLoop::KeyEvent(const SDL_KeyboardEvent& event, bool down)
         {
             bool shuffleEnabled = !projectm_get_shuffle_enabled(_projectMHandle);
             projectm_set_shuffle_enabled(_projectMHandle, shuffleEnabled);
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, shuffleEnabled ? "Shuffle Enabled" : "Shuffle Disabled");
         }
             break;
 

--- a/src/RenderLoop.cpp
+++ b/src/RenderLoop.cpp
@@ -56,21 +56,11 @@ void RenderLoop::PollEvents()
                 break;
 
             case SDL_KEYDOWN:
-                if (projectm_is_text_input_active(_projectMHandle, true))
-                {
-                    SearchKeyEvent(event.key);
-                }
-                else
-                {
-                    KeyEvent(event.key, true);
-                }
+                KeyEvent(event.key, true);
                 break;
 
             case SDL_KEYUP:
-                if (!projectm_is_text_input_active(_projectMHandle, true))
-                {
-                    KeyEvent(event.key, false);
-                }
+                KeyEvent(event.key, false);
                 break;
 
             case SDL_MOUSEBUTTONDOWN:
@@ -79,14 +69,6 @@ void RenderLoop::PollEvents()
 
             case SDL_MOUSEBUTTONUP:
                 MouseUpEvent(event.button);
-                break;
-
-            case SDL_TEXTINPUT:
-                if (projectm_is_text_input_active(_projectMHandle, true))
-                {
-                    projectm_set_search_text(_projectMHandle, event.text.text);
-                    projectm_populate_preset_menu(_projectMHandle);
-                }
                 break;
 
             case SDL_QUIT:
@@ -164,8 +146,6 @@ void RenderLoop::KeyEvent(const SDL_KeyboardEvent& event, bool down)
         {
             bool aspectCorrectionEnabled = !projectm_get_aspect_correction(_projectMHandle);
             projectm_set_aspect_correction(_projectMHandle, aspectCorrectionEnabled);
-            projectm_set_toast_message(_projectMHandle, aspectCorrectionEnabled ? "Aspect Correction Enabled"
-                                                                                : "Aspect Correction Disabled");
         }
             break;
 
@@ -173,7 +153,6 @@ void RenderLoop::KeyEvent(const SDL_KeyboardEvent& event, bool down)
         case SDLK_d:
             // Write next rendered frame to file
             projectm_key_handler(_projectMHandle, PROJECTM_KEYDOWN, PROJECTM_K_d, PROJECTM_KMOD_NONE);
-            projectm_set_toast_message(_projectMHandle, "Main Texture Captured");
             break;
 #endif
 
@@ -193,7 +172,6 @@ void RenderLoop::KeyEvent(const SDL_KeyboardEvent& event, bool down)
             if (modifierPressed)
             {
                 _audioCapture.NextAudioDevice();
-                projectm_set_toast_message(_projectMHandle, _audioCapture.AudioDeviceName().c_str());
             }
             break;
 
@@ -231,7 +209,6 @@ void RenderLoop::KeyEvent(const SDL_KeyboardEvent& event, bool down)
         {
             bool shuffleEnabled = !projectm_get_shuffle_enabled(_projectMHandle);
             projectm_set_shuffle_enabled(_projectMHandle, shuffleEnabled);
-            projectm_set_toast_message(_projectMHandle, shuffleEnabled ? "Shuffle Enabled" : "Shuffle Disabled");
         }
             break;
 
@@ -334,10 +311,6 @@ void RenderLoop::SearchKeyEvent(const SDL_KeyboardEvent& event)
             {
                 _wantsToQuit = true;
             }
-            break;
-
-        case SDLK_BACKSPACE:
-            projectm_delete_search_text(_projectMHandle);
             break;
 
         case SDLK_RETURN:


### PR DESCRIPTION
- Add an optional filter for patterns to include in the playlist by removing any patterns that don't contain the filter in their filename
- Add an `exclude.txt` list of patterns to exclude
- Add the current pattern to exclude list when pressing "minus" key

Note this builds on #46 and #44