### PR TITLE
Fix SDL audio capture issues

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,32 +1,39 @@
-name: Build
+name: Ubuntu Linux (x86_64)
 
 on: [ push, pull_request ]
 
 jobs:
   build:
+    name: Static libprojectM
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
 
-      - run: sudo apt install build-essential libgl1-mesa-dev mesa-common-dev libsdl2-dev libpoco-dev
-
-      - name: Get libprojectM
-        run: git clone --depth 1 https://github.com/projectM-visualizer/projectm.git
-      - name: Build libprojectM
+      - name: Install Build Dependencies
         run: |
-          cd projectm
-          mkdir build
-          cd build
-          cmake ..
-          make -j4
+          sudo apt update
+          sudo apt install build-essential libgl1-mesa-dev mesa-common-dev libsdl2-dev libpoco-dev ninja-build
 
-      - name: Install projectM
-        run: cd projectm/build && sudo make install
+      - name: Checkout libprojectM Sources
+        uses: actions/checkout@v3
+        with:
+          repository: projectM-visualizer/projectm
+          path: projectm
+
+      - name: Build/Install libprojectM
+        run: |
+          mkdir cmake-build-libprojectm
+          cmake -G Ninja -S projectm -B cmake-build-libprojectm -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install-libprojectm
+          cmake --build cmake-build-libprojectm --parallel --target install
+
+      - name: Checkout frontend-sdl2 Sources
+        uses: actions/checkout@v3
+        with:
+          path: frontend-sdl2
+          submodules: recursive
 
       - name: Build frontend-sdl2
         run: |
-          mkdir build
-          cd build
-          cmake ..
-          make -j4
+          mkdir cmake-build-frontend-sdl2
+          cmake -G Ninja -S frontend-sdl2 -B cmake-build-frontend-sdl2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install-libprojectm -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install-frontend-sdl2
+          cmake --build cmake-build-frontend-sdl2 --parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,17 +19,10 @@ project(projectM-SDL
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
-set(PROJECTM_LINKAGE "shared" CACHE STRING "Set to either shared or static to specify how libprojectM should be linked. Defaults to shared.")
 set(SDL2_LINKAGE "shared" CACHE STRING "Set to either shared or static to specify how libSDL2 should be linked. Defaults to shared.")
 
 set(DEFAULT_PRESETS_PATH "\${application.dir}/presets" CACHE STRING "Default presets path in the configuration file.")
 set(DEFAULT_TEXTURES_PATH "\${application.dir}/textures" CACHE STRING "Default textures path in the configuration file.")
-
-if(NOT PROJECTM_LINKAGE STREQUAL "shared" AND NOT PROJECTM_LINKAGE STREQUAL "static")
-    message(FATAL_ERROR "Invalid libprojectM linkage provided in PROJECTM_LINKAGE: \"${PROJECTM_LINKAGE}\".\n"
-                        "Please specify either \"shared\" or \"static\"."
-            )
-endif()
 
 if(NOT SDL2_LINKAGE STREQUAL "shared" AND NOT SDL2_LINKAGE STREQUAL "static")
     message(FATAL_ERROR "Invalid libSDL2 linkage provided in SDL2_LINKAGE: \"${SDL2_LINKAGE}\".\n"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(NOT SDL2_LINKAGE STREQUAL "shared" AND NOT SDL2_LINKAGE STREQUAL "static")
             )
 endif()
 
-find_package(libprojectM REQUIRED)
+find_package(libprojectM REQUIRED COMPONENTS Playlist)
 find_package(SDL2 REQUIRED)
 find_package(Poco REQUIRED COMPONENTS Util)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
-
-if(CMAKE_VERSION VERSION_LESS 3.19 AND CMAKE_GENERATOR STREQUAL "Xcode")
-    message(AUTHOR_WARNING "Using a CMake version before 3.19 with a recent Xcode SDK and the Xcode generator "
-            "will likely result in CMake failing to find the AppleClang compiler. Either upgrade CMake to at least "
-            "version 3.19 or use a different generator, e.g. \"Unix Makefiles\" or \"Ninja\".")
-endif()
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)

--- a/src/AudioCaptureImpl_SDL.cpp
+++ b/src/AudioCaptureImpl_SDL.cpp
@@ -30,8 +30,7 @@ AudioCaptureImpl::~AudioCaptureImpl()
 std::map<int, std::string> AudioCaptureImpl::AudioDeviceList()
 {
     std::map<int, std::string> deviceList{
-        { -1, "Default capturing device" }
-    };
+        {-1, "Default capturing device"}};
 
     auto recordingDeviceCount = SDL_GetNumAudioDevices(true);
 
@@ -141,12 +140,6 @@ void AudioCaptureImpl::AudioInputCallback(void* userData, unsigned char* stream,
 
     unsigned int samples = len / sizeof(float) / instance->_channels;
 
-    if (instance->_channels == 1)
-    {
-        projectm_pcm_add_float(instance->_projectMHandle, reinterpret_cast<float*>(stream), samples, PROJECTM_MONO);
-    }
-    else if (instance->_channels == 2)
-    {
-        projectm_pcm_add_float(instance->_projectMHandle, reinterpret_cast<float*>(stream), samples, PROJECTM_STEREO);
-    }
+    projectm_pcm_add_float(instance->_projectMHandle, reinterpret_cast<float*>(stream), samples,
+                           static_cast<projectm_channels>(instance->_channels));
 }

--- a/src/AudioCaptureImpl_SDL.h
+++ b/src/AudioCaptureImpl_SDL.h
@@ -25,7 +25,7 @@ public:
      * @brief Returns a map of available recording devices.
      * @return A vector of available audio device IDs and names.
      */
-    std::map<int, std::string> AudioDeviceList() ;
+    std::map<int, std::string> AudioDeviceList();
 
     /**
      * @brief Starts audio capturing with the first available device.
@@ -58,7 +58,7 @@ public:
      *
      * @todo Store audio samples internally and push them to projectM when requested.
      */
-    void FillBuffer() {};
+    void FillBuffer(){};
 
 protected:
     /**
@@ -76,14 +76,15 @@ protected:
      * @param stream
      * @param len
      */
-    static void AudioInputCallback(void *userData, unsigned char *stream, int len);
+    static void AudioInputCallback(void* userData, unsigned char* stream, int len);
 
-    projectm* _projectMHandle{ nullptr }; //!< Handle if the projectM instance that will receive the audio data.
-    int _currentAudioDeviceIndex{ -1 }; //!< Currently selected audio device index.
-    SDL_AudioDeviceID _currentAudioDeviceID{ 0 }; //!< Device ID of the currently opened audio device.
-    int _channels{ 2 };
+    projectm* _projectMHandle{nullptr}; //!< Handle if the projectM instance that will receive the audio data.
+    int32_t _currentAudioDeviceIndex{-1}; //!< Currently selected audio device index.
+    SDL_AudioDeviceID _currentAudioDeviceID{0}; //!< Device ID of the currently opened audio device.
+    uint32_t _channels{2};
 
-    Poco::Logger& _logger{ Poco::Logger::get("AudioCapture.SDL") }; //!< The class logger.
+    constexpr static uint32_t _requestedSampleFrequency{44100}; //!< Requested sample frequency. Currently hardcoded as 44100 Hz, as this is what the spectrum analyzer expects.
+    uint32_t _requestedSampleCount{44100U / 60U}; //!< Requested audio buffer size. Determines how often SDL will call AudioInputCallback() with new data, and how much data is delivered on each call.
+
+    Poco::Logger& _logger{Poco::Logger::get("AudioCapture.SDL")}; //!< The class logger.
 };
-
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,7 +44,6 @@ endif()
 target_compile_definitions(projectMSDL
         PRIVATE
         PROJECTMSDL_VERSION="${PROJECT_VERSION}"
-        LIBPROJECTM_BUILD_VERSION="${libprojectM_VERSION}"
         )
 
 target_link_libraries(projectMSDL

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 
-set(PROJECTM_CONFIGURATION_FILE "${CMAKE_CURRENT_BINARY_DIR}/projectMSDL.properties" PARENT_SCOPE)
-configure_file(resources/projectMSDL.properties.in ${PROJECTM_CONFIGURATION_FILE} @ONLY)
+set(PROJECTM_CONFIGURATION_FILE "${CMAKE_CURRENT_BINARY_DIR}/projectMSDL.properties")
+set(PROJECTM_CONFIGURATION_FILE "${PROJECTM_CONFIGURATION_FILE}" PARENT_SCOPE)
+configure_file(resources/projectMSDL.properties.in "${PROJECTM_CONFIGURATION_FILE}" @ONLY)
 
 add_executable(projectMSDL WIN32
         AudioCapture.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,6 @@ target_compile_definitions(projectMSDL
 
 target_link_libraries(projectMSDL
         PRIVATE
-        libprojectM::${PROJECTM_LINKAGE}
         libprojectM::playlist
         Poco::Util
         SDL2::SDL2$<$<STREQUAL:${SDL2_LINKAGE},static>:-static>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ target_compile_definitions(projectMSDL
 target_link_libraries(projectMSDL
         PRIVATE
         libprojectM::${PROJECTM_LINKAGE}
+        libprojectM::playlist
         Poco::Util
         SDL2::SDL2$<$<STREQUAL:${SDL2_LINKAGE},static>:-static>
         SDL2::SDL2main

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,15 +55,8 @@ target_link_libraries(projectMSDL
         )
 
 if(MSVC)
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.16")
-        set_target_properties(projectMSDL
-                PROPERTIES
-                VS_DPI_AWARE "PerMonitor"
-                )
-    else()
-        message(AUTHOR_WARNING
-                "You're using a CMake version less than 3.16 with Visual Studio.\n"
-                "The resulting projectMSDL executable will not be DPI-aware and possibly render at a "
-                "lower-than-expected resolution on high-DPI displays.")
-    endif()
+    set_target_properties(projectMSDL
+            PROPERTIES
+            VS_DPI_AWARE "PerMonitor"
+            )
 endif()

--- a/src/ProjectMSDLApplication.cpp
+++ b/src/ProjectMSDLApplication.cpp
@@ -164,6 +164,10 @@ void ProjectMSDLApplication::DisplayHelp(POCO_UNUSED const std::string& name, PO
     SDL_VERSION(&sdlBuild);
     SDL_GetVersion(&sdlLoaded);
 
+    auto* projectMVersion = projectm_get_version_string();
+    std::string projectMRuntimeVersion(projectMVersion);
+    projectm_free_string(projectMVersion);
+
     formatter.setUsage(config().getString("application.name") + " [options]");
     formatter.setHeader(Poco::format(R"(
 projectM SDL Standalone Visualizer
@@ -171,10 +175,11 @@ projectM SDL Standalone Visualizer
 Licensed under the GNU General Public License 3.0
 
 Application version: %s
-Built against libprojectM version: %s
+Built/running with libprojectM version: %s / %s
 Built against SDL version: %?d.%?d.%?d (running with %?d.%?d.%?d))",
                                      std::string(PROJECTMSDL_VERSION),
-                                     std::string(LIBPROJECTM_BUILD_VERSION),
+                                     std::string(PROJECTM_VERSION_STRING),
+                                     projectMRuntimeVersion,
                                      sdlBuild.major, sdlBuild.minor, sdlBuild.patch,
                                      sdlLoaded.major, sdlLoaded.minor, sdlLoaded.patch));
 

--- a/src/ProjectMWrapper.cpp
+++ b/src/ProjectMWrapper.cpp
@@ -55,6 +55,7 @@ void ProjectMWrapper::initialize(Poco::Util::Application& app)
         if (!presetPath.empty())
         {
             projectm_playlist_add_path(_playlist, presetPath.c_str(), true, false);
+            projectm_playlist_sort(_playlist, 0, projectm_playlist_size(_playlist), SORT_PREDICATE_FILENAME_ONLY, SORT_ORDER_ASCENDING);
         }
     }
 }

--- a/src/ProjectMWrapper.cpp
+++ b/src/ProjectMWrapper.cpp
@@ -56,18 +56,6 @@ void ProjectMWrapper::initialize(Poco::Util::Application& app)
         {
             projectm_playlist_add_path(_playlist, presetPath.c_str(), true, false);
         }
-
-        if (!_config->getBool("enableSplash", true))
-        {
-            if (_config->getBool("shuffleEnabled", true))
-            {
-                projectm_playlist_play_next(_playlist, true);
-            }
-            else
-            {
-                projectm_playlist_set_position(_playlist, 0, true);
-            }
-        }
     }
 }
 
@@ -108,4 +96,19 @@ void ProjectMWrapper::RenderFrame() const
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
     projectm_opengl_render_frame(_projectM);
+}
+
+void ProjectMWrapper::DisplayInitialPreset()
+{
+    if (!_config->getBool("enableSplash", true))
+    {
+        if (_config->getBool("shuffleEnabled", true))
+        {
+            projectm_playlist_play_next(_playlist, true);
+        }
+        else
+        {
+            projectm_playlist_set_position(_playlist, 0, true);
+        }
+    }
 }

--- a/src/ProjectMWrapper.h
+++ b/src/ProjectMWrapper.h
@@ -1,11 +1,12 @@
 #pragma once
 
 #include <libprojectM/projectM.h>
+#include <libprojectM/playlist.h>
 
 #include <Poco/Logger.h>
 
-#include <Poco/Util/Subsystem.h>
 #include <Poco/Util/AbstractConfiguration.h>
+#include <Poco/Util/Subsystem.h>
 
 #include <memory>
 
@@ -18,7 +19,13 @@ public:
      * Returns the projectM instance handle.
      * @return The projectM instance handle used to call API functions.
      */
-    projectm* ProjectM() const;
+    projectm_handle ProjectM() const;
+
+    /**
+     * Returns the playlist handle.
+     * @return The plaslist handle.
+     */
+    projectm_playlist_handle Playlist() const;
 
     /**
      * Renders a single projectM frame.
@@ -33,16 +40,10 @@ public:
 
 
 protected:
-    /**
-     * @brief Sets the text of the help menu overlay.
-     */
-    void SetHelpText();
-
     Poco::AutoPtr<Poco::Util::AbstractConfiguration> _config; //!< View of the "projectM" configuration subkey.
 
-    projectm* _projectM{ nullptr }; //!< Pointer to the projectM instance used by the application.
+    projectm_handle _projectM{nullptr}; //!< Pointer to the projectM instance used by the application.
+    projectm_playlist_handle _playlist{nullptr}; //!< Pointer to the projectM playlist manager instance.
 
-    Poco::Logger& _logger{ Poco::Logger::get("SDLRenderingWindow") }; //!< The class logger.
+    Poco::Logger& _logger{Poco::Logger::get("SDLRenderingWindow")}; //!< The class logger.
 };
-
-

--- a/src/ProjectMWrapper.h
+++ b/src/ProjectMWrapper.h
@@ -34,6 +34,12 @@ public:
 
     int TargetFPS();
 
+    /**
+     * @brief If splash is disabled, shows the initial preset.
+     * If shuffle is on, a random preset will be picked. Otherwise, the first playlist item is displayed.
+     */
+    void DisplayInitialPreset();
+
     void initialize(Poco::Util::Application& app) override;
 
     void uninitialize() override;

--- a/src/RenderLoop.cpp
+++ b/src/RenderLoop.cpp
@@ -22,8 +22,7 @@ void RenderLoop::Run()
 
     projectm_playlist_set_preset_switched_event_callback(_playlistHandle, &RenderLoop::PresetSwitchedEvent, static_cast<void*>(this));
 
-    // Update title bar with initial preset.
-    PresetSwitchedEvent(true, projectm_playlist_get_position(_playlistHandle), this);
+    _projectMWrapper.DisplayInitialPreset();
 
     while (!_wantsToQuit)
     {

--- a/src/RenderLoop.cpp
+++ b/src/RenderLoop.cpp
@@ -206,6 +206,7 @@ void RenderLoop::KeyEvent(const SDL_KeyboardEvent& event, bool down)
 
         case SDLK_SPACE:
             projectm_set_preset_locked(_projectMHandle, !projectm_get_preset_locked(_projectMHandle));
+            UpdateWindowTitle();
             break;
 
         case SDLK_UP:
@@ -286,10 +287,24 @@ void RenderLoop::PresetSwitchedEvent(bool isHardCut, unsigned int index, void* c
 {
     auto that = reinterpret_cast<RenderLoop*>(context);
     auto presetName = projectm_playlist_item(that->_playlistHandle, index);
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Displaying preset: %s\n", presetName);
-
-    std::string newTitle = "projectM ➫ " + std::string(presetName);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Displaying preset: %s\n", presetName);;
     projectm_free_string(presetName);
 
-    that->_sdlRenderingWindow.SetTitle(newTitle);
+    that->UpdateWindowTitle();
+}
+
+void RenderLoop::UpdateWindowTitle()
+{
+    auto presetName = projectm_playlist_item(_playlistHandle, projectm_playlist_get_position(_playlistHandle));
+
+    Poco::Path presetFile(presetName);
+    projectm_free_string(presetName);
+
+    std::string newTitle = "projectM ➫ " + presetFile.getBaseName();
+    if (projectm_get_preset_locked(_projectMHandle))
+    {
+        newTitle += " [locked]";
+    }
+
+    _sdlRenderingWindow.SetTitle(newTitle);
 }

--- a/src/RenderLoop.cpp
+++ b/src/RenderLoop.cpp
@@ -146,7 +146,7 @@ void RenderLoop::KeyEvent(const SDL_KeyboardEvent& event, bool down)
 #ifdef _DEBUG
         case SDLK_d:
             // Write next rendered frame to file
-            projectm_write_debug_image_on_next_frame(_projectMHandle);
+            projectm_write_debug_image_on_next_frame(_projectMHandle, nullptr);
             break;
 #endif
 

--- a/src/RenderLoop.h
+++ b/src/RenderLoop.h
@@ -69,6 +69,11 @@ protected:
      */
     static void PresetSwitchedEvent(bool isHardCut, unsigned int index, void* context);
 
+    /**
+     * Sets the window title to the current preset name.
+     */
+    void UpdateWindowTitle();
+
     AudioCapture& _audioCapture;
     ProjectMWrapper& _projectMWrapper;
     SDLRenderingWindow& _sdlRenderingWindow;

--- a/src/RenderLoop.h
+++ b/src/RenderLoop.h
@@ -14,9 +14,7 @@ public:
     void Run();
 
 protected:
-
-    struct ModifierKeyStates
-    {
+    struct ModifierKeyStates {
         bool _shiftPressed{false}; //!< L/R shift keys
         bool _ctrlPressed{false}; //!< L/R control keys
         bool _altPressed{false}; //!< L/R alt keys
@@ -75,17 +73,17 @@ protected:
     ProjectMWrapper& _projectMWrapper;
     SDLRenderingWindow& _sdlRenderingWindow;
 
-    projectm* _projectMHandle{ nullptr };
+    projectm_handle _projectMHandle{nullptr};
+    projectm_playlist_handle _playlistHandle{nullptr};
 
-    bool _wantsToQuit{ false };
+    bool _wantsToQuit{false};
 
-    bool _mouseDown{ false }; //!< Left mouse button is pressed
+    bool _mouseDown{false}; //!< Left mouse button is pressed
 
-    int _renderWidth{ 0 };
-    int _renderHeight{ 0 };
+    int _renderWidth{0};
+    int _renderHeight{0};
 
     ModifierKeyStates _keyStates; //!< Current "pressed" states of modifier keys
 
-    Poco::Logger& _logger{ Poco::Logger::get("RenderLoop") }; //!< The class logger.
+    Poco::Logger& _logger{Poco::Logger::get("RenderLoop")}; //!< The class logger.
 };
-


### PR DESCRIPTION
Two issues with SDL audio capturing are fixed here:

1. The input buffer size was fixed to the maximum sample count stored by libprojectM (e.g. the internal sample buffer size), which is currently 2048 samples. This caused SDL to collect data until this size was reached, calling the audio callback only with about 21 FPS, which would only update waveforms every third frame making it look jaggy.  
    
    Now, the input buffer size is set to match the target FPS value, and is clamped to a minimum of 300 samples (~144 FPS) and the maximum buffer size projectM can use (21 FPS). This should effctively smooth the waveform display even on high FPS monitors, while still working well with very low FPS settings.
  
2. The `projectm_pcm_add_float()` was only called with 1 or 2 channels, but if the channel count was different, it was never called, not rendering any audio data at all. As SDL guarantees that front left/right channels are always delivered at interleave index 0 and 1, we can simply provide the actual channel count to the library, and it wil pick the correct samples from the audio buffer.

The input buffer size could in theory be matched to the actual FPS, but this would require restarting the SDL capture thread every few frames after requesting a new input buffer format, which isn't really a good idea.