### PR TITLE
updated cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT SDL2_LINKAGE STREQUAL "shared" AND NOT SDL2_LINKAGE STREQUAL "static")
             )
 endif()
 
-find_package(libprojectM REQUIRED COMPONENTS Playlist)
+find_package(projectM4 REQUIRED COMPONENTS Playlist)
 find_package(SDL2 REQUIRED)
 find_package(Poco REQUIRED COMPONENTS Util)
 
@@ -42,4 +42,4 @@ include(packaging.cmake)
 
 message(STATUS "SDL version: ${SDL2_VERSION}")
 message(STATUS "Poco version: ${Poco_VERSION}")
-message(STATUS "projectM version: ${libprojectM_VERSION}")
+message(STATUS "projectM version: ${projectM4_VERSION}")

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ make
 
 If all runs successfully, you should have an executable.
 
+#### Linux
+[Note: 'make install' is broken at the moment. Just copy the binary 'projectMSDL' to your choice of run-path. E.g.]
+```shell
+cp src/projectMSDL ~/bin
+```
+Create a configuration file or projectMSDL will complain, a lot.
+```shell
+mkdir ~/.config/projectM
+cp src/projectMSDL.properties ~/.config/projectM
+```
+The default audio device (-1) may or may not be your actual default audio output. `projectMSDL -l` will list audio devices; hopefully, one of them looks familiar - like "Monitor of ... digital stereo" or "Monitor of USB Audio Device ..." (if you have one of those).
+
+
 ### Run
 
 You should have a directory of visual presets you wish to use. You can fetch a giant trove of curated presets [here](https://github.com/projectM-visualizer/presets-cream-of-the-crop).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ make
 If all runs successfully, you should have an executable.
 
 #### Linux
-[Note: 'make install' is broken at the moment. Just copy the binary 'projectMSDL' to your choice of run-path. E.g.]
+[Note: 'make install' is unimplemented at the moment. Just copy the binary 'projectMSDL' to your choice of run-path. E.g.]
 ```shell
 cp src/projectMSDL ~/bin
 ```

--- a/dependencies_check.cmake
+++ b/dependencies_check.cmake
@@ -1,5 +1,5 @@
-if(libprojectM_VERSION VERSION_LESS 3.1.13)
-    message(FATAL_ERROR "libprojectM version 3.13 or higher is required. Version found: ${libprojectM_VERSION}.")
+if(projectM4_VERSION VERSION_LESS 3.1.13)
+    message(FATAL_ERROR "libprojectM version 3.13 or higher is required. Version found: ${projectM4_VERSION}.")
 endif()
 
 if(SDL2_VERSION VERSION_LESS 2.0.5)

--- a/dependencies_check.cmake
+++ b/dependencies_check.cmake
@@ -1,5 +1,5 @@
-if(projectM4_VERSION VERSION_LESS 3.1.13)
-    message(FATAL_ERROR "libprojectM version 3.13 or higher is required. Version found: ${projectM4_VERSION}.")
+if(projectM4_VERSION VERSION_LESS 4.0.0)
+    message(FATAL_ERROR "libprojectM version 4.0.0 or higher is required. Version found: ${projectM4_VERSION}.")
 endif()
 
 if(SDL2_VERSION VERSION_LESS 2.0.5)

--- a/src/AudioCaptureImpl_SDL.cpp
+++ b/src/AudioCaptureImpl_SDL.cpp
@@ -2,7 +2,7 @@
 
 #include <Poco/Util/Application.h>
 
-#include <libprojectM/projectM.h>
+#include <projectM-4/projectM.h>
 
 AudioCaptureImpl::AudioCaptureImpl()
     : _requestedSampleCount(projectm_pcm_get_max_samples())

--- a/src/AudioCaptureImpl_WASAPI.cpp
+++ b/src/AudioCaptureImpl_WASAPI.cpp
@@ -1,6 +1,6 @@
 #include "AudioCaptureImpl_WASAPI.h"
 
-#include <libprojectM/projectM.h>
+#include <projectM-4/projectM.h>
 
 #include <Poco/UnicodeConverter.h>
 

--- a/src/ProjectMSDLApplication.cpp
+++ b/src/ProjectMSDLApplication.cpp
@@ -175,7 +175,7 @@ projectM SDL Standalone Visualizer
 Licensed under the GNU General Public License 3.0
 
 Application version: %s
-Built/running with libprojectM version: %s / %s
+Built/running with projectM4 version: %s / %s
 Built against SDL version: %?d.%?d.%?d (running with %?d.%?d.%?d))",
                                      std::string(PROJECTMSDL_VERSION),
                                      std::string(PROJECTM_VERSION_STRING),

--- a/src/ProjectMWrapper.h
+++ b/src/ProjectMWrapper.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <libprojectM/projectM.h>
-#include <libprojectM/playlist.h>
+#include <projectM-4/projectM.h>
+#include <projectM-4/playlist.h>
 
 #include <Poco/Logger.h>
 


### PR DESCRIPTION
The SDL2 frontend would not build on my system. cmake complains:
```shell
CMake Error at CMakeLists.txt:27 (find_package):
  By not providing "FindlibprojectM.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "libprojectM", but CMake did not find one.

  Could not find a package configuration file provided by "libprojectM" with
  any of the following names:

    libprojectMConfig.cmake
    libprojectm-config.cmake

  Add the installation prefix of "libprojectM" to CMAKE_PREFIX_PATH or set
  "libprojectM_DIR" to a directory containing one of the above files.  If
  "libprojectM" provides a separate development package or SDK, be sure it
  has been installed.
```

I've updated several instances of `libprojectM` with `projectM4` in the cmake files, and updated the source files.

Also, `cmake install` produces a binary that won't link with the system libprojectM4. I don't know how to fix that.

Thanks! I got this running now and it made my day!