### PR TITLE
Free strings from playlist library with the correct method.

### DIFF
--- a/src/RenderLoop.cpp
+++ b/src/RenderLoop.cpp
@@ -288,7 +288,7 @@ void RenderLoop::PresetSwitchedEvent(bool isHardCut, unsigned int index, void* c
     auto that = reinterpret_cast<RenderLoop*>(context);
     auto presetName = projectm_playlist_item(that->_playlistHandle, index);
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Displaying preset: %s\n", presetName);;
-    projectm_free_string(presetName);
+    projectm_playlist_free_string(presetName);
 
     that->UpdateWindowTitle();
 }
@@ -298,7 +298,7 @@ void RenderLoop::UpdateWindowTitle()
     auto presetName = projectm_playlist_item(_playlistHandle, projectm_playlist_get_position(_playlistHandle));
 
     Poco::Path presetFile(presetName);
-    projectm_free_string(presetName);
+    projectm_playlist_free_string(presetName);
 
     std::string newTitle = "projectM ➫ " + presetFile.getBaseName();
     if (projectm_get_preset_locked(_projectMHandle))


### PR DESCRIPTION
Causes heap issues in Windows DLL-based builds otherwise.