### PR TITLE
Add version check for buggy Poco libraries.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,10 +1,13 @@
-name: Ubuntu Linux (x86_64)
+# Build check workflow
+# Used to check if projectMSDL compiles with upstream master of libprojectM.
+# The resulting binaries are not considered for public use though.
+name: Build Check
 
 on: [ push, pull_request ]
 
 jobs:
-  build:
-    name: Static libprojectM
+  build-linux:
+    name: Ubuntu Linux, x86_64
     runs-on: ubuntu-latest
 
     steps:
@@ -12,19 +15,37 @@ jobs:
       - name: Install Build Dependencies
         run: |
           sudo apt update
-          sudo apt install build-essential libgl1-mesa-dev mesa-common-dev libsdl2-dev libpoco-dev ninja-build
+          sudo apt install build-essential libgl1-mesa-dev mesa-common-dev libsdl2-dev libpoco-dev ninja-build libssl-dev
+
+      # We need to build/link Poco ourselves as static libraries, because Ubuntu Jammy ships with a broken Poco 1.11.0
+      - name: Checkout Poco Sources
+        uses: actions/checkout@v3
+        with:
+          repository: pocoproject/poco
+          path: poco
+          ref: 'poco-1.12.2'
+          submodules: recursive
+
+      - name: Build Poco
+        run: |
+          mkdir cmake-build-poco
+          cmake -G Ninja -S poco -B cmake-build-poco -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install-poco -DENABLE_MONGODB=OFF -DENABLE_REDIS=OFF -DENABLE_PAGECOMPILER=OFF -DENABLE_PAGECOMPILER_FILE2PAGE=OFF -DENABLE_ACTIVERECORD=OFF -DENABLE_ACTIVERECORD_COMPILER=OFF -DENABLE_DATA_ODBC=OFF -DENABLE_DATA_POSTGRESQL=OFF -DENABLE_DATA_MYSQL=OFF -DENABLE_JWT=OFF -DENABLE_PROMETHEUS=OFF
+          cmake --build cmake-build-poco --parallel
+          cmake --install "${{ github.workspace }}/cmake-build-poco"
 
       - name: Checkout libprojectM Sources
         uses: actions/checkout@v3
         with:
           repository: projectM-visualizer/projectm
           path: projectm
+          submodules: recursive
 
       - name: Build/Install libprojectM
         run: |
           mkdir cmake-build-libprojectm
-          cmake -G Ninja -S projectm -B cmake-build-libprojectm -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install-libprojectm
-          cmake --build cmake-build-libprojectm --parallel --target install
+          cmake -G Ninja -S projectm -B cmake-build-libprojectm -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install-libprojectm
+          cmake --build cmake-build-libprojectm --parallel
+          cmake --install "${{ github.workspace }}/cmake-build-libprojectm"
 
       - name: Checkout frontend-sdl2 Sources
         uses: actions/checkout@v3
@@ -35,5 +56,76 @@ jobs:
       - name: Build frontend-sdl2
         run: |
           mkdir cmake-build-frontend-sdl2
-          cmake -G Ninja -S frontend-sdl2 -B cmake-build-frontend-sdl2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install-libprojectm -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install-frontend-sdl2
+          cmake -G Ninja -S frontend-sdl2 -B cmake-build-frontend-sdl2 -DCMAKE_BUILD_TYPE=Release "-DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install-libprojectm;${GITHUB_WORKSPACE}/install-poco" "-DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install-frontend-sdl2"
           cmake --build cmake-build-frontend-sdl2 --parallel
+  #          cmake --install "${{ github.workspace }}/cmake-build-frontend-sdl2"
+
+  build-windows:
+    name: Windows, x64
+    runs-on: windows-latest
+
+    steps:
+      - name: Install Build Dependencies
+        run: vcpkg --triplet=x64-windows-static install glew gtest sdl2 poco
+
+      - name: Checkout libprojectM Sources
+        uses: actions/checkout@v3
+        with:
+          repository: projectM-visualizer/projectm
+          path: projectm
+          submodules: recursive
+
+      - name: Build/Install libprojectM
+        run: |
+          mkdir cmake-build-libprojectm
+          cmake -G "Visual Studio 17 2022" -A "X64" -S "${{ github.workspace }}/projectm" -B "${{ github.workspace }}/cmake-build-libprojectm" -DCMAKE_TOOLCHAIN_FILE="${Env:VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows-static -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install-libprojectm" -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>" -DCMAKE_VERBOSE_MAKEFILE=YES -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=NO
+          cmake --build "${{ github.workspace }}/cmake-build-libprojectm" --config Release --parallel
+          cmake --install "${{ github.workspace }}/cmake-build-libprojectm" --config Release
+
+      - name: Checkout projectMSDL Sources
+        uses: actions/checkout@v3
+        with:
+          path: frontend-sdl2
+          submodules: recursive
+
+      - name: Build projectMSDL
+        run: |
+          mkdir cmake-build-frontend-sdl2
+          cmake -G "Visual Studio 17 2022" -A "X64" -S "${{ github.workspace }}/frontend-sdl2" -B "${{ github.workspace }}/cmake-build-frontend-sdl2" -DCMAKE_TOOLCHAIN_FILE="${Env:VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows-static  -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install-libprojectm" -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install-frontend-sdl2" -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>" -DCMAKE_VERBOSE_MAKEFILE=YES -DSDL2_LINKAGE=static -DBUILD_TESTING=YES
+          cmake --build "${{ github.workspace }}/cmake-build-frontend-sdl2" --parallel --config Release
+  #          cmake --install "${{ github.workspace }}/cmake-build-frontend-sdl2" --config Release
+
+  build-darwin:
+    name: macOS, x86_64
+    runs-on: macos-latest
+
+    steps:
+      - name: Install Build Dependencies
+        run: brew install sdl2 ninja googletest poco
+
+      - name: Checkout libprojectM Sources
+        uses: actions/checkout@v3
+        with:
+          repository: projectM-visualizer/projectm
+          path: projectm
+          submodules: recursive
+
+      - name: Build/Install libprojectM
+        run: |
+          mkdir cmake-build-libprojectm
+          cmake -G Ninja -S "${{ github.workspace }}/projectm" -B "${{ github.workspace }}/cmake-build-libprojectm" -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}//install-libprojectm"
+          cmake --build "${{ github.workspace }}/cmake-build-libprojectm" --parallel
+          cmake --install "${{ github.workspace }}/cmake-build-libprojectm"
+
+      - name: Checkout projectMSDL Sources
+        uses: actions/checkout@v3
+        with:
+          path: frontend-sdl2
+          submodules: recursive
+
+      - name: Build projectMSDL
+        run: |
+          mkdir cmake-build-frontend-sdl2
+          cmake -G Ninja -S "${{ github.workspace }}/frontend-sdl2" -B "${{ github.workspace }}/cmake-build-frontend-sdl2" -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install-libprojectm" -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}//install-frontend-sdl2"
+          cmake --build "${{ github.workspace }}/cmake-build-frontend-sdl2" --parallel
+#          cmake --install "${{ github.workspace }}/cmake-build-frontend-sdl2"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 
 find_package(projectM4 REQUIRED COMPONENTS Playlist)
 find_package(SDL2 REQUIRED)
-find_package(Poco REQUIRED COMPONENTS Util)
+find_package(Poco REQUIRED COMPONENTS JSON XML Util Foundation)
 
 include(SDL2Target)
 include(dependencies_check.cmake)

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ This is a reference implementation of an applicatiaon that makes use of the proj
 
 It will listen to audio input and produce mesmerizing visuals. Some commands are supported.
 
-This project is in a bit of a transition state and is in the process of being modernized. There are many rough edges at present.
+This project is in a bit of a transition state and is in the process of being modernized. There are many rough edges at
+present.
 
 ## Building from source
 
 ### Build and install libprojectM
 
-First, [build](https://github.com/projectM-visualizer/projectm/wiki/Building-libprojectM) and `sudo make install` [libprojectM](https://github.com/projectM-visualizer/projectm)
+First, [build](https://github.com/projectM-visualizer/projectm/wiki/Building-libprojectM)
+and `sudo make install` [libprojectM](https://github.com/projectM-visualizer/projectm)
 
 ### Dependencies
 
@@ -20,6 +22,9 @@ First, [build](https://github.com/projectM-visualizer/projectm/wiki/Building-lib
 apt install libsdl2-dev libpoco-dev cmake  # debian/ubuntu
 brew install sdl2  # macOS
 ```
+
+**Important**: projectMSDL will _not compile_ against Poco versions from 1.10.0 up to 1.11.1, as these versions of Poco
+include a serious issue that causes the application to crash. Either use Poco 1.9.x, or upgrade to 1.11.2 or higher.
 
 ### Build
 
@@ -33,21 +38,28 @@ make
 If all runs successfully, you should have an executable.
 
 #### Linux
+
 [Note: 'make install' is unimplemented at the moment. Just copy the binary 'projectMSDL' to your choice of run-path. E.g.]
+
 ```shell
 cp src/projectMSDL ~/bin
 ```
+
 Create a configuration file or projectMSDL will complain, a lot.
+
 ```shell
 mkdir ~/.config/projectM
 cp src/projectMSDL.properties ~/.config/projectM
 ```
-The default audio device (-1) may or may not be your actual default audio output. `projectMSDL -l` will list audio devices; hopefully, one of them looks familiar - like "Monitor of ... digital stereo" or "Monitor of USB Audio Device ..." (if you have one of those).
 
+The default audio device (-1) may or may not be your actual default audio output. `projectMSDL -l` will list audio
+devices; hopefully, one of them looks familiar - like "Monitor of ... digital stereo" or "Monitor of USB Audio
+Device ..." (if you have one of those).
 
 ### Run
 
-You should have a directory of visual presets you wish to use. You can fetch a giant trove of curated presets [here](https://github.com/projectM-visualizer/presets-cream-of-the-crop).
+You should have a directory of visual presets you wish to use. You can fetch a giant trove of curated
+presets [here](https://github.com/projectM-visualizer/presets-cream-of-the-crop).
 
 Provide the presets path you wish to use when starting projectMSDL:
 

--- a/dependencies_check.cmake
+++ b/dependencies_check.cmake
@@ -6,6 +6,14 @@ if(SDL2_VERSION VERSION_LESS 2.0.5)
     message(FATAL_ERROR "libSDL version 2.0.5 or higher is required. Version found: ${SDL2_VERSION}.")
 endif()
 
+if(Poco_VERSION VERSION_LESS 1.11.2 AND Poco_VERSION GREATER_EQUAL 1.10.0)
+    message(FATAL_ERROR "Your Poco library contains a serious bug which will cause crashes. Your version is ${Poco_VERSION}.
+Affected versions are 1.10.0 to 1.11.1, including. Please upgrade Poco to at least 1.11.2 or downgrade to 1.9.x.
+projectMSDL will NOT work with the affected versions.
+See https://github.com/pocoproject/poco/issues/3507 for details on this particular issue.
+")
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND SDL2_VERSION VERSION_LESS 2.0.16)
     message(AUTHOR_WARNING
             "NOTE: libSDL 2.0.15 and lower do not support capture from PulseAudio \"monitor\" devices.\n"


### PR DESCRIPTION
Since the application will crash due to either heap corruption or double-free issues, it won't make much sense to allow people to compile it against affected versions.