### PR TITLE
Added option to remove cursor from sdl window

### DIFF
--- a/src/ProjectMSDLApplication.cpp
+++ b/src/ProjectMSDLApplication.cpp
@@ -159,6 +159,10 @@ void ProjectMSDLApplication::defineOptions(Poco::Util::OptionSet& options)
     options.addOption(Option("beatSensitivity", "", "Beat sensitivity. Between 0.0 and 5.0. Default 1.0.",
                              false, "<number>", true)
                           .binding("projectM.beatSensitivity", _commandLineOverrides));
+    options.addOption(Option("showCursor", "", "Shows cursor",
+                             false, "true/false", true)
+                          .binding("window.showCursor", _commandLineOverrides));
+
 
 }
 

--- a/src/RenderLoop.cpp
+++ b/src/RenderLoop.cpp
@@ -71,6 +71,9 @@ void RenderLoop::PollEvents()
                 break;
         }
     }
+
+    SDL_ShowCursor(SDL_DISABLE);
+
 }
 
 void RenderLoop::CheckViewportSize()

--- a/src/RenderLoop.cpp
+++ b/src/RenderLoop.cpp
@@ -72,7 +72,9 @@ void RenderLoop::PollEvents()
         }
     }
 
-    SDL_ShowCursor(SDL_DISABLE);
+    if (!_sdlRenderingWindow.getConfig()->getBool("showCursor", true)) {
+        SDL_ShowCursor(SDL_DISABLE);
+    }
 
 }
 

--- a/src/SDLRenderingWindow.cpp
+++ b/src/SDLRenderingWindow.cpp
@@ -19,6 +19,11 @@ void SDLRenderingWindow::initialize(Poco::Util::Application& app)
     }
 }
 
+Poco::AutoPtr<Poco::Util::AbstractConfiguration> SDLRenderingWindow::getConfig() const
+{
+    return _config;
+}
+
 void SDLRenderingWindow::uninitialize()
 {
     if (_renderingWindow)

--- a/src/SDLRenderingWindow.h
+++ b/src/SDLRenderingWindow.h
@@ -68,6 +68,12 @@ public:
      */
     void NextDisplay();
 
+    /**
+     * @brief Retrieves the configuration view for the window.
+     * @return The configuration view for the window.
+     */
+    Poco::AutoPtr<Poco::Util::AbstractConfiguration> getConfig() const;
+
 protected:
 
     /**


### PR DESCRIPTION
Hey folks, 
Ever opened the frontend but couldn't figure out where to best place the os cursor so it's not as visible? 
I created a commandline option to remove it if preferred for an unobstructed experience.