### PR TITLE
Redirect users to file new bug reports in the main libprojectM repository.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Create new issue
+    url: https://github.com/projectM-visualizer/projectm/issues/new/choose
+    about: Please open new issues in the main projectM repository. We will then move the issue into the correct repository for you.


### PR DESCRIPTION
Disables the default link for creating blank issues and adds a link to the main repo for new issues.

See PR https://github.com/projectM-visualizer/projectm/pull/801 for details.