### PR TITLE
Remove Windows build check workaround and update actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
 
       # We need to build/link Poco ourselves as static libraries, because Ubuntu Jammy ships with a broken Poco 1.11.0
       - name: Checkout Poco Sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: pocoproject/poco
           path: poco
@@ -34,7 +34,7 @@ jobs:
           cmake --install "${{ github.workspace }}/cmake-build-poco"
 
       - name: Checkout libprojectM Sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: projectM-visualizer/projectm
           path: projectm
@@ -48,7 +48,7 @@ jobs:
           cmake --install "${{ github.workspace }}/cmake-build-libprojectm"
 
       - name: Checkout frontend-sdl2 Sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: frontend-sdl2
           submodules: recursive
@@ -65,12 +65,6 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: Setup MSVC dev command prompt
-        uses: TheMrMilchmann/setup-msvc-dev@v3
-        with:
-          arch: x64
-          toolset: 14.38.33130
-
       - name: Export GitHub Actions cache environment variables
         uses: actions/github-script@v6
         with:
@@ -79,7 +73,7 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Checkout libprojectM Sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: projectM-visualizer/projectm
           path: projectm
@@ -95,7 +89,7 @@ jobs:
           cmake --install "${{ github.workspace }}/cmake-build-libprojectm" --config Release
 
       - name: Checkout projectMSDL Sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: frontend-sdl2
           submodules: recursive
@@ -118,7 +112,7 @@ jobs:
         run: brew install sdl2 ninja googletest poco
 
       - name: Checkout libprojectM Sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: projectM-visualizer/projectm
           path: projectm
@@ -132,7 +126,7 @@ jobs:
           cmake --install "${{ github.workspace }}/cmake-build-libprojectm"
 
       - name: Checkout projectMSDL Sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: frontend-sdl2
           submodules: recursive


### PR DESCRIPTION
The Windows Platform SDK issue was fixed by GitHub, so we can remove the no longer working workaround.

Also updated the checkout action to v4.