### PR TITLE
Add option to accept an X11 window id and draw in it rather than opening a new window.

### DIFF
--- a/src/ProjectMSDLApplication.cpp
+++ b/src/ProjectMSDLApplication.cpp
@@ -233,6 +233,11 @@ void ProjectMSDLApplication::defineOptions(Poco::Util::OptionSet& options)
     options.addOption(Option("beatSensitivity", "", "Beat sensitivity. Between 0.0 and 2.0. Default 1.0.",
                              false, "<number>", true)
                           .binding("projectM.beatSensitivity", _commandLineOverrides));
+#ifdef __linux__
+    options.addOption(Option("window_id", "wid", "Existing X11 window id to draw in.",
+                             false, "<number>", true)
+                          .binding("window.wid", _commandLineOverrides));
+#endif
 }
 
 int ProjectMSDLApplication::main(POCO_UNUSED const std::vector<std::string>& args)

--- a/src/SDLRenderingWindow.cpp
+++ b/src/SDLRenderingWindow.cpp
@@ -204,6 +204,10 @@ void SDLRenderingWindow::CreateSDLWindow()
     int top{_config->getInt("top", 0)};
     bool positionOverridden = _config->getBool("overridePosition", false);
 
+#ifdef __linux__
+    uint64_t wid{_config->getUInt64("wid", 0)};
+#endif
+
     if (!positionOverridden)
     {
         left = SDL_WINDOWPOS_UNDEFINED;
@@ -249,8 +253,18 @@ void SDLRenderingWindow::CreateSDLWindow()
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 #endif
 
-    _renderingWindow = SDL_CreateWindow("projectM", left, top, width, height,
-                                        SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+#ifdef __linux__
+    if (wid) {
+        SDL_SetHint(SDL_HINT_VIDEO_FOREIGN_WINDOW_OPENGL, "1");
+        _renderingWindow = SDL_CreateWindowFrom((void*)wid);
+    }
+    else
+#endif
+    {
+      _renderingWindow = SDL_CreateWindow("projectM", left, top, width, height,
+                                          SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+    }
+
     if (!_renderingWindow)
     {
         auto errorMessage = "Could not create SDL rendering window. Error: " + std::string(SDL_GetError());


### PR DESCRIPTION
This feature can be used with `xwinwrap` to make `projectMSDL` into a live wallpaper/desktop background, eg:

`xwinwrap -fs -nf -b -un -ov -fdt -- projectMSDL -wid %WID`

The proposed argument name is not camelcase like the existing ones, but `--window-id` is used for this same feature by all the `xscreensaver` plugins and the short form `-wid` is used by `mpv` and `mplayer`.

This is an especially nice effect when using a tiling window manager with terminal and editor windows with translucent backgrounds, but also requires a compositor. I use `picom`.

Thanks to [this forum comment](https://community.khronos.org/t/embedded-window/110159/7) for the SDL_HINT_VIDEO_FOREIGN_WINDOW_OPENGL hint, which is needed for OpenGL rendering context creation to succeed.