### PR TITLE
Fix GL linking, add ref args to release workflows and update workflow actions

### DIFF
--- a/.github/workflows/buildcheck.yaml
+++ b/.github/workflows/buildcheck.yaml
@@ -19,7 +19,7 @@ jobs:
 
       # We need to build/link Poco ourselves as static libraries, because Ubuntu Jammy ships with a broken Poco 1.11.0
       - name: Checkout Poco Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: pocoproject/poco
           path: poco
@@ -48,7 +48,7 @@ jobs:
           cmake --install "${{ github.workspace }}/cmake-build-poco"
 
       - name: Checkout libprojectM Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: projectM-visualizer/projectm
           path: projectm
@@ -65,7 +65,7 @@ jobs:
           cmake --install "${{ github.workspace }}/cmake-build-libprojectm"
 
       - name: Checkout frontend-sdl2 Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: frontend-sdl2
           submodules: recursive
@@ -85,7 +85,7 @@ jobs:
           cpack -G DEB
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: projectMSDL-buildcheck-linux
           path: cmake-build-frontend-sdl2/*.deb
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: Checkout vcpkg
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: microsoft/vcpkg
           path: vcpkg
@@ -127,7 +127,7 @@ jobs:
             -Source "${{ env.FEED_URL }}"
 
       - name: Checkout libprojectM Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: projectM-visualizer/projectm
           path: projectm
@@ -141,7 +141,7 @@ jobs:
           cmake --install "${{ github.workspace }}/cmake-build-libprojectm" --config Release
 
       - name: Checkout projectMSDL Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: frontend-sdl2
           submodules: recursive
@@ -158,7 +158,7 @@ jobs:
           cpack -G ZIP
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: projectMSDL-buildcheck-windows
           path: cmake-build-frontend-sdl2/*.zip
@@ -172,7 +172,7 @@ jobs:
         run: brew install sdl2 ninja googletest poco
 
       - name: Checkout libprojectM Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: projectM-visualizer/projectm
           path: projectm
@@ -186,7 +186,7 @@ jobs:
           cmake --install "${{ github.workspace }}/cmake-build-libprojectm"
 
       - name: Checkout projectMSDL Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: frontend-sdl2
           submodules: recursive
@@ -203,7 +203,7 @@ jobs:
           cpack -G TGZ
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: projectMSDL-buildcheck-macos
           path: cmake-build-frontend-sdl2/*.tar.gz

--- a/.github/workflows/release-linux.yaml
+++ b/.github/workflows/release-linux.yaml
@@ -6,7 +6,39 @@ name: Build Release Package for Linux
 
 on:
   workflow_dispatch:
+    inputs:
+      projectMSDLref:
+        description: "projectMSDL Git reference (branch, tag or commit hash)"
+        required: true
+        default: "master"
+        type: string
+      projectMref:
+        description: "libprojectM Git reference (branch, tag or commit hash)"
+        required: true
+        default: "master"
+        type: string
+      pocoref:
+        description: "POCO Git reference (branch, tag or commit hash)"
+        required: true
+        default: "poco-1.14.1"
+        type: string
   workflow_call:
+    inputs:
+      projectMSDLref:
+        description: "projectMSDL Git reference (branch, tag or commit hash)"
+        required: false
+        default: "master"
+        type: string
+      projectMref:
+        description: "libprojectM Git reference (branch, tag or commit hash)"
+        required: false
+        default: "master"
+        type: string
+      pocoref:
+        description: "POCO Git reference (branch, tag or commit hash)"
+        required: false
+        default: "poco-1.14.1"
+        type: string
 
 jobs:
   build-deb:
@@ -28,7 +60,7 @@ jobs:
         with:
           repository: pocoproject/poco
           path: poco
-          ref: 'poco-1.14.1'
+          ref: ${{ inputs.pocoref }}
           submodules: recursive
 
       - name: Build Poco
@@ -57,6 +89,7 @@ jobs:
         with:
           repository: projectM-visualizer/projectm
           path: projectm
+          ref: ${{ inputs.projectMref }}
           submodules: recursive
 
       - name: Build/Install libprojectM
@@ -73,6 +106,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: frontend-sdl2
+          ref: ${{ inputs.projectMSDLref }}
           submodules: recursive
 
       - name: Checkout Cream of the Crop preset pack
@@ -130,7 +164,7 @@ jobs:
         with:
           repository: pocoproject/poco
           path: poco
-          ref: 'poco-1.14.1'
+          ref: ${{ inputs.pocoref }}
           submodules: recursive
 
       - name: Build Poco
@@ -159,6 +193,7 @@ jobs:
         with:
           repository: projectM-visualizer/projectm
           path: projectm
+          ref: ${{ inputs.projectMref }}
           submodules: recursive
 
       - name: Build/Install libprojectM
@@ -175,6 +210,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: frontend-sdl2
+          ref: ${{ inputs.projectMSDLref }}
           submodules: recursive
 
       - name: Checkout Cream of the Crop preset pack

--- a/.github/workflows/release-linux.yaml
+++ b/.github/workflows/release-linux.yaml
@@ -56,7 +56,7 @@ jobs:
       # and other distros may ship different versions as well. POCO as a C++ library has no stable ABI, so each minor
       # release increments the SO version by one.
       - name: Checkout Poco Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: pocoproject/poco
           path: poco
@@ -85,7 +85,7 @@ jobs:
           cmake --install "${{ github.workspace }}/cmake-build-poco"
 
       - name: Checkout libprojectM Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: projectM-visualizer/projectm
           path: projectm
@@ -103,20 +103,20 @@ jobs:
           cmake --install "${{ github.workspace }}/cmake-build-libprojectm"
 
       - name: Checkout frontend-sdl2 Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: frontend-sdl2
           ref: ${{ inputs.projectMSDLref }}
           submodules: recursive
 
       - name: Checkout Cream of the Crop preset pack
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: projectM-visualizer/presets-cream-of-the-crop
           path: presets-cream-of-the-crop
 
       - name: Checkout Milkdrop Texture Pack
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: projectM-visualizer/presets-milkdrop-texture-pack
           path: presets-milkdrop-texture-pack
@@ -140,7 +140,7 @@ jobs:
           cpack -G DEB
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: projectMSDL-Linux-DEB-x86_64
           path: cmake-build-frontend-sdl2/*.deb
@@ -160,7 +160,7 @@ jobs:
       # and other distros may ship different versions as well. POCO as a C++ library has no stable ABI, so each minor
       # release increments the SO version by one.
       - name: Checkout Poco Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: pocoproject/poco
           path: poco
@@ -189,7 +189,7 @@ jobs:
           cmake --install "${{ github.workspace }}/cmake-build-poco"
 
       - name: Checkout libprojectM Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: projectM-visualizer/projectm
           path: projectm
@@ -207,20 +207,20 @@ jobs:
           cmake --install "${{ github.workspace }}/cmake-build-libprojectm"
 
       - name: Checkout frontend-sdl2 Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: frontend-sdl2
           ref: ${{ inputs.projectMSDLref }}
           submodules: recursive
 
       - name: Checkout Cream of the Crop preset pack
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: projectM-visualizer/presets-cream-of-the-crop
           path: presets-cream-of-the-crop
 
       - name: Checkout Milkdrop Texture Pack
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: projectM-visualizer/presets-milkdrop-texture-pack
           path: presets-milkdrop-texture-pack
@@ -245,7 +245,7 @@ jobs:
           cpack -G TGZ
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: projectMSDL-Linux-Portable-x86_64
           path: cmake-build-frontend-sdl2/*.tar.gz

--- a/.github/workflows/release-macos.yaml
+++ b/.github/workflows/release-macos.yaml
@@ -4,7 +4,39 @@ name: Build Release Package for macOS
 
 on:
   workflow_dispatch:
+    inputs:
+      projectMSDLref:
+        description: "projectMSDL Git reference (branch, tag or commit hash)"
+        required: true
+        default: "master"
+        type: string
+      projectMref:
+        description: "libprojectM Git reference (branch, tag or commit hash)"
+        required: true
+        default: "master"
+        type: string
+      pocoref:
+        description: "POCO Git reference (branch, tag or commit hash)"
+        required: true
+        default: "poco-1.14.1"
+        type: string
   workflow_call:
+    inputs:
+      projectMSDLref:
+        description: "projectMSDL Git reference (branch, tag or commit hash)"
+        required: false
+        default: "master"
+        type: string
+      projectMref:
+        description: "libprojectM Git reference (branch, tag or commit hash)"
+        required: false
+        default: "master"
+        type: string
+      pocoref:
+        description: "POCO Git reference (branch, tag or commit hash)"
+        required: false
+        default: "poco-1.14.1"
+        type: string
     secrets:
       MACOS_CERTIFICATE_APPLICATION:
         required: true
@@ -52,7 +84,7 @@ jobs:
         with:
           repository: pocoproject/poco
           path: poco
-          ref: 'poco-1.14.1'
+          ref: ${{ inputs.pocoref }}
           submodules: recursive
 
       - name: Build Poco
@@ -86,6 +118,7 @@ jobs:
         with:
           repository: projectM-visualizer/projectm
           path: projectm
+          ref: ${{ inputs.projectMref }}
           submodules: recursive
 
       - name: Build/Install libprojectM
@@ -103,6 +136,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: frontend-sdl2
+          ref: ${{ inputs.projectMSDLref }}
           submodules: recursive
 
       - name: Checkout Cream of the Crop preset pack

--- a/.github/workflows/release-macos.yaml
+++ b/.github/workflows/release-macos.yaml
@@ -61,7 +61,7 @@ jobs:
       # We need to build third-party libraries (POCO, SDL2 and projectM) ourselves, as neither Homebrew
       # nor vcpkg support building universal binaries.
       - name: Checkout libSDL2 Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: libsdl-org/SDL
           path: libsdl2
@@ -80,7 +80,7 @@ jobs:
           cmake --install "${{ github.workspace }}/cmake-build-libsdl2"
 
       - name: Checkout Poco Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: pocoproject/poco
           path: poco
@@ -114,7 +114,7 @@ jobs:
           cmake --install "${{ github.workspace }}/cmake-build-poco"
 
       - name: Checkout libprojectM Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: projectM-visualizer/projectm
           path: projectm
@@ -133,20 +133,20 @@ jobs:
           cmake --install "${{ github.workspace }}/cmake-build-libprojectm"
 
       - name: Checkout projectMSDL Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: frontend-sdl2
           ref: ${{ inputs.projectMSDLref }}
           submodules: recursive
 
       - name: Checkout Cream of the Crop preset pack
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: projectM-visualizer/presets-cream-of-the-crop
           path: presets-cream-of-the-crop
 
       - name: Checkout Milkdrop Texture Pack
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: projectM-visualizer/presets-milkdrop-texture-pack
           path: presets-milkdrop-texture-pack
@@ -237,7 +237,7 @@ jobs:
           xcrun stapler staple "${{ github.workspace }}/install/projectM.app"
 
       - name: Upload .app Bundle Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: projectMSDL-macOS-Universal-APP
           path: install/
@@ -287,7 +287,7 @@ jobs:
           xcrun stapler staple "$PKG_FILE"
 
       - name: Upload PKG Installer Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: projectMSDL-macOS-Universal-PKG
           path: projectM-*.pkg
@@ -331,7 +331,7 @@ jobs:
           xcrun stapler staple "$DMG_FILE"
 
       - name: Upload DMG Installer Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: projectMSDL-macOS-Universal-DMG
           path: projectM-*.dmg

--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -3,9 +3,22 @@
 # including projectM.
 name: Build Release Package for Windows
 
+# On Windows, we're using vcpkg for the latest POCO and liprojectM packages.
 on:
   workflow_dispatch:
+    inputs:
+      projectMSDLref:
+        description: "projectMSDL Git reference (branch, tag or commit hash)"
+        required: true
+        default: "master"
+        type: string
   workflow_call:
+    inputs:
+      projectMSDLref:
+        description: "projectMSDL Git reference (branch, tag or commit hash)"
+        required: false
+        default: "master"
+        type: string
 
 jobs:
   build:
@@ -47,6 +60,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: frontend-sdl2
+          ref: ${{ inputs.projectMSDLref }}
           submodules: recursive
 
       - name: Checkout Cream of the Crop preset pack

--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout vcpkg
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: microsoft/vcpkg
           path: vcpkg
@@ -57,20 +57,20 @@ jobs:
             -Source "${{ env.FEED_URL }}"
 
       - name: Checkout projectMSDL Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: frontend-sdl2
           ref: ${{ inputs.projectMSDLref }}
           submodules: recursive
 
       - name: Checkout Cream of the Crop preset pack
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: projectM-visualizer/presets-cream-of-the-crop
           path: presets-cream-of-the-crop
 
       - name: Checkout Milkdrop Texture Pack
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: projectM-visualizer/presets-milkdrop-texture-pack
           path: presets-milkdrop-texture-pack
@@ -96,7 +96,7 @@ jobs:
           cpack -G ZIP
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: projectMSDL-Windows-Portable-x64
           path: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 option(ENABLE_FLAT_PACKAGE "Creates a \"flat\" install layout with the executable, configuration file(s) and preset/texture dirs directly in the install prefix." OFF)
 option(ENABLE_INSTALL_BDEPS "Installs all shared libraries projectMSDL requires to run. On some platforms, CMake 3.31 or higher is required for this to work!" OFF)
+option(ENABLE_GLES "Build the application to use OpenGL ES instead of Core GL. May not work on all platforms and requires CMake 3.27 or higher." OFF)
 
 set(PROJECTMSDL_PROPERTIES_FILENAME "projectMSDL.properties")
 
@@ -97,6 +98,14 @@ endif()
 
 find_package(projectM4 REQUIRED COMPONENTS Playlist)
 find_package(SDL2 REQUIRED)
+if (NOT ENABLE_GLES)
+    find_package(OpenGL REQUIRED)
+else ()
+    if (CMAKE_VERSION VERSION_LESS 3.27)
+        message(FATAL_ERROR "CMake 3.27 or higher is required to build with OpenGL ES 3!")
+    endif ()
+    find_package(OpenGL REQUIRED COMPONENTS GLES3)
+endif()
 find_package(Poco REQUIRED COMPONENTS JSON XML Util Foundation)
 
 if(Poco_VERSION VERSION_GREATER_EQUAL 1.14.0)

--- a/ImGui.cmake
+++ b/ImGui.cmake
@@ -42,6 +42,13 @@ target_include_directories(ImGui
         ${SDL2_INCLUDE_DIRS}
         )
 
+if (ENABLE_GLES)
+    target_compile_definitions(ImGui
+            PUBLIC
+            IMGUI_IMPL_OPENGL_ES3
+            )
+endif ()
+
 # Build font embedding tool
 add_executable(ImGuiBinaryToCompressedC EXCLUDE_FROM_ALL
         vendor/imgui/misc/fonts/binary_to_compressed_c.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,13 @@ set_target_properties(projectMSDL PROPERTIES
         MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/resources/Info.plist.in"
         )
 
+if (ENABLE_GLES)
+    target_compile_definitions(projectMSDL
+            PUBLIC
+            USE_GLES
+            )
+endif ()
+
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     target_sources(projectMSDL
             PRIVATE
@@ -56,7 +63,7 @@ else ()
             )
 endif ()
 
-# GLEW needs to be initialized if libprojectM depends on it.
+# GLEW needs to be initialized if libprojectM depends on it (<v4.2).
 if (TARGET GLEW::glew OR TARGET GLEW::glew_s)
     target_compile_definitions(projectMSDL
             PRIVATE
@@ -81,6 +88,7 @@ target_link_libraries(projectMSDL
         Poco::Util
         SDL2::SDL2$<$<STREQUAL:${SDL2_LINKAGE},static>:-static>
         SDL2::SDL2main
+        OpenGL::$<IF:$<BOOL:${ENABLE_GLES}>,GLES3,GL>
         )
 
 if (MSVC)

--- a/src/SDLRenderingWindow.cpp
+++ b/src/SDLRenderingWindow.cpp
@@ -238,9 +238,9 @@ void SDLRenderingWindow::CreateSDLWindow()
     }
 
 #if USE_GLES
-    // use GLES 2.0
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+    // use GLES 3.2
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
 #else
     // projectM Requires at least Core Profile 3.30 for samplers etc.


### PR DESCRIPTION
A few maintenance fixes:
- Always explicitly link OpenGL, don't rely on libprojectM's transitive dependency which will be gone in 4.2 (linking against libprojectM master builds already failed).
- Add `ENABLE_GLES` CMake option to add proper GLES support to the app, enabling building on RPi and other GLES devices.
- Added arguments for Git refs in release build workflows for POCO, libprojectM and projectMSDL (except Windows, where only projectMSDL is parameterized as we use vcpkg for the other deps).
- Updated the `checkout` and `upload-artifact` GHA workflow actions to v6/Node.JS 24 as the older ones are deprecated.