### PR TITLE
docs: Add macOS full build from source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,41 @@ mkdir cmake-build
 cmake -G Xcode -S . -B cmake-build -DCMAKE_CONFIGURATION_TYPES=Debug,Release
 cmake --build cmake-build --config Release
 ```
+
+#### macOS: Full build from source (including libprojectM)
+
+Pre-built macOS binaries are not currently published. Use the following to build everything from source:
+
+**Prerequisites**
+
+```shell
+xcode-select --install
+brew install cmake sdl2 poco freetype git
+```
+
+**1. Build and install libprojectM**
+
+```shell
+git clone --recurse-submodules https://github.com/projectM-visualizer/projectm.git
+cmake -S projectm -B projectm/cmake-build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=~/dev/projectm-install \
+  -DENABLE_EMSCRIPTEN=OFF
+cmake --build projectm/cmake-build --config Release --parallel $(sysctl -n hw.logicalcpu)
+cmake --install projectm/cmake-build
+```
+
+**2. Build frontend-sdl2**
+
+```shell
+git clone --recurse-submodules https://github.com/projectM-visualizer/frontend-sdl2.git
+cmake -S frontend-sdl2 -B frontend-sdl2/cmake-build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH=~/dev/projectm-install \
+  -DCMAKE_INSTALL_PREFIX=~/dev/projectm-install
+cmake --build frontend-sdl2/cmake-build --config Release --parallel $(sysctl -n hw.logicalcpu)
+cmake --install frontend-sdl2/cmake-build
+```
+
+`projectM.app` will be in `~/dev/projectm-install/`. Edit
+`projectM.app/Contents/Resources/projectMSDL.properties` to set your preset and texture paths, then launch the app.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ cmake -G Ninja -S . -B cmake-build \
   -DCMAKE_INSTALL_PREFIX=~/dev/projectm-install \
   -DENABLE_PLAYLIST=ON \
   -DBUILD_SHARED_LIBS=ON
+# Optional: add -DENABLE_MACOS_FRAMEWORK=ON to build as a .framework bundle
+# (libprojectM 4.2+ only — easier to link against in Xcode projects)
 cmake --build cmake-build --parallel
 cmake --install cmake-build
 cd ..

--- a/README.md
+++ b/README.md
@@ -164,32 +164,36 @@ Pre-built macOS binaries are not currently published. Use the following to build
 
 ```shell
 xcode-select --install
-brew install cmake sdl2 poco freetype git
+brew install cmake ninja sdl2 poco freetype git
 ```
 
 **1. Build and install libprojectM**
 
 ```shell
 git clone --recurse-submodules https://github.com/projectM-visualizer/projectm.git
-cmake -S projectm -B projectm/cmake-build \
+cd projectm && mkdir cmake-build
+cmake -G Ninja -S . -B cmake-build \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=~/dev/projectm-install \
-  -DENABLE_EMSCRIPTEN=OFF
-cmake --build projectm/cmake-build --config Release --parallel $(sysctl -n hw.logicalcpu)
-cmake --install projectm/cmake-build
+  -DENABLE_PLAYLIST=ON \
+  -DBUILD_SHARED_LIBS=ON
+cmake --build cmake-build --parallel
+cmake --install cmake-build
+cd ..
 ```
 
 **2. Build frontend-sdl2**
 
 ```shell
 git clone --recurse-submodules https://github.com/projectM-visualizer/frontend-sdl2.git
-cmake -S frontend-sdl2 -B frontend-sdl2/cmake-build \
+cd frontend-sdl2 && mkdir cmake-build
+cmake -G Ninja -S . -B cmake-build \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_PREFIX_PATH=~/dev/projectm-install \
-  -DCMAKE_INSTALL_PREFIX=~/dev/projectm-install
-cmake --build frontend-sdl2/cmake-build --config Release --parallel $(sysctl -n hw.logicalcpu)
-cmake --install frontend-sdl2/cmake-build
+  -DCMAKE_INSTALL_PREFIX=~/dev/projectm-app
+cmake --build cmake-build --parallel
+cmake --install cmake-build
 ```
 
-`projectM.app` will be in `~/dev/projectm-install/`. Edit
+`projectM.app` will be in `~/dev/projectm-app/`. Edit
 `projectM.app/Contents/Resources/projectMSDL.properties` to set your preset and texture paths, then launch the app.


### PR DESCRIPTION
The existing macOS section only covers generating an Xcode project for frontend-sdl2, but omits the prerequisite step of building libprojectM from source. Pre-built macOS binaries are not published, leaving macOS users without a working path.

This adds a self-contained walkthrough under the existing `### macOS` section covering:
- Homebrew prerequisites
- Building libprojectM from source with `CMAKE_INSTALL_PREFIX`
- Building frontend-sdl2 with `CMAKE_PREFIX_PATH` pointing at the libprojectM install
- Where to find the resulting `.app` and how to configure it

Tested on macOS (Apple Silicon) as of April 2026.